### PR TITLE
Add docker-compose for qbittorrent service

### DIFF
--- a/services/qbittorrent/docker-compose.yml
+++ b/services/qbittorrent/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - sqlbak.start.first=false
       - com.centurylinklabs.watchtower.enable=true
       - traefik.enable=true
-      - traefik.http.routers.qbittorrent.rule=Host(`qbittorrent.${MY_DOMAIN}`)
+      - traefik.http.routers.qbittorrent.rule=Host(`qbittorrent.${USER_DOMAIN}`)
       - traefik.http.routers.qbittorrent.entryPoints=websecure
       - traefik.http.routers.qbittorrent.tls=true
       - traefik.http.routers.qbittorrent.tls.certResolver=le

--- a/services/qbittorrent/docker-compose.yml
+++ b/services/qbittorrent/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:latest
+    container_name: qbittorrent
+    hostname: qbittorrent
+    networks:
+      - traefik
+    ports:
+      - 8080:8080
+      - 6881:6881
+      - 6881:6881/udp
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.qbittorrent.rule=Host(`qbittorrent.${MY_DOMAIN}`)
+      - traefik.http.routers.qbittorrent.entryPoints=websecure
+      - traefik.http.routers.qbittorrent.tls=true
+      - traefik.http.routers.qbittorrent.tls.certResolver=le
+      - traefik.http.services.qbittorrent.loadBalancer.server.port=8080
+    environment:
+      - TZ=America/Sao_Paulo
+      - PUID=${USER_ID}
+      - PGID=${GROUP_ID}
+      - WEBUI_PORT=8080
+      - TORRENTING_PORT=6881
+    volumes:
+      - /home/pi/centerMedia/SupportApps/qbittorrent/config:/config
+      - /home/pi/downloads:/downloads
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary

- Adds `services/qbittorrent/docker-compose.yml` for the qBittorrent torrent client
- Exposes web UI on port 8080 with Traefik routing via `qbittorrent.${MY_DOMAIN}`
- Exposes torrenting port 6881 (TCP + UDP)
- Maps `/downloads` to `/home/pi/downloads` (existing HDD shortcut)
- Config stored at `/home/pi/centerMedia/SupportApps/qbittorrent/config`

> **Note:** On first start, a temporary admin password is printed to the container logs. You must change it in Settings → Web UI to make it permanent — otherwise it resets on every restart.

## Test plan

- [ ] Run `docker compose up -d` in `services/qbittorrent/`
- [ ] Check container logs for the temporary admin password on first run
- [ ] Verify web UI is accessible at `qbittorrent.<domain>`
- [ ] Change the default password in Settings → Web UI
- [ ] Confirm downloads land in `/home/pi/downloads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)