### PR TITLE
Add docker-compose for zerobyte service

### DIFF
--- a/services/zerobyte/docker-compose.yml
+++ b/services/zerobyte/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - sqlbak.start.first=false
       - com.centurylinklabs.watchtower.enable=true
       - traefik.enable=true
-      - traefik.http.routers.zerobyte.rule=Host(`zerobyte.${MY_DOMAIN}`)
+      - traefik.http.routers.zerobyte.rule=Host(`zerobyte.${USER_DOMAIN}`)
       - traefik.http.routers.zerobyte.entryPoints=websecure
       - traefik.http.routers.zerobyte.tls=true
       - traefik.http.routers.zerobyte.tls.certResolver=le

--- a/services/zerobyte/docker-compose.yml
+++ b/services/zerobyte/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  zerobyte:
+    image: ghcr.io/nicotsx/zerobyte:latest
+    container_name: zerobyte
+    hostname: zerobyte
+    networks:
+      - traefik
+    ports:
+      - 4096:4096
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.zerobyte.rule=Host(`zerobyte.${MY_DOMAIN}`)
+      - traefik.http.routers.zerobyte.entryPoints=websecure
+      - traefik.http.routers.zerobyte.tls=true
+      - traefik.http.routers.zerobyte.tls.certResolver=le
+      - traefik.http.services.zerobyte.loadBalancer.server.port=4096
+    environment:
+      - TZ=America/Sao_Paulo
+      - PUID=${USER_ID}
+      - PGID=${GROUP_ID}
+      - BASE_URL=https://zerobyte.${MY_DOMAIN}
+      - APP_SECRET=${ZEROBYTE_APP_SECRET}
+      - PORT=4096
+    volumes:
+      - /home/pi/centerMedia/SupportApps/zerobyte/data:/var/lib/zerobyte
+      - /etc/localtime:/etc/localtime:ro
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse:/dev/fuse
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary

- Adds `services/zerobyte/docker-compose.yml` for [Zerobyte](https://github.com/nicotsx/zerobyte), a web-based backup automation tool powered by Restic
- Exposes web UI on port 4096 with Traefik routing via `zerobyte.${MY_DOMAIN}`
- Data stored at `/home/pi/centerMedia/SupportApps/zerobyte/data`
- Requires `ZEROBYTE_APP_SECRET` env var (32+ character encryption key for the database)
- Includes `SYS_ADMIN` capability and `/dev/fuse` device for remote mount support (NFS, SMB, etc.)

## Test plan

- [ ] Set `ZEROBYTE_APP_SECRET` (min 32 chars) in the environment
- [ ] Run `docker compose up -d` in `services/zerobyte/`
- [ ] Verify web UI is accessible at `zerobyte.<domain>`
- [ ] Configure a backup repository and schedule a test backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)