### PR TITLE
Add docker-compose for pihole service

### DIFF
--- a/services/pihole/docker-compose.yml
+++ b/services/pihole/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - sqlbak.start.first=false
       - com.centurylinklabs.watchtower.enable=true
       - traefik.enable=true
-      - traefik.http.routers.pihole.rule=Host(`pihole.${MY_DOMAIN}`)
+      - traefik.http.routers.pihole.rule=Host(`pihole.${USER_DOMAIN}`)
       - traefik.http.routers.pihole.entryPoints=websecure
       - traefik.http.routers.pihole.tls=true
       - traefik.http.routers.pihole.tls.certResolver=le

--- a/services/pihole/docker-compose.yml
+++ b/services/pihole/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  pihole:
+    image: pihole/pihole:latest
+    container_name: pihole
+    hostname: pihole
+    networks:
+      - traefik
+    ports:
+      - 53:53/tcp
+      - 53:53/udp
+      - 80:80/tcp
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.pihole.rule=Host(`pihole.${MY_DOMAIN}`)
+      - traefik.http.routers.pihole.entryPoints=websecure
+      - traefik.http.routers.pihole.tls=true
+      - traefik.http.routers.pihole.tls.certResolver=le
+      - traefik.http.services.pihole.loadBalancer.server.port=80
+    environment:
+      - TZ=America/Sao_Paulo
+      - PUID=${USER_ID}
+      - PGID=${GROUP_ID}
+      - FTLCONF_webserver_api_password=${PIHOLE_PASSWORD}
+      - FTLCONF_dns_listeningMode=ALL
+    volumes:
+      - /home/pi/centerMedia/SupportApps/pihole/etc-pihole:/etc/pihole
+      - /home/pi/centerMedia/SupportApps/pihole/etc-dnsmasq.d:/etc/dnsmasq.d
+    cap_add:
+      - NET_ADMIN
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary

- Adds `services/pihole/docker-compose.yml` for [Pi-hole](https://pi-hole.net/), a network-wide DNS ad blocker
- Exposes web UI on port 80 with Traefik routing via `pihole.${MY_DOMAIN}`
- Exposes DNS on port 53 (TCP + UDP) directly for network-wide use
- Requires `PIHOLE_PASSWORD` env var for the admin panel
- Includes `NET_ADMIN` capability (required for DNS/DHCP operations)

> **Note:** Port 53 may conflict with `systemd-resolved` on the host. If DNS fails to bind, disable the local resolver first: `sudo systemctl disable --now systemd-resolved`

## Test plan

- [ ] Set `PIHOLE_PASSWORD` in the environment
- [ ] Run `docker compose up -d` in `services/pihole/`
- [ ] Verify web UI is accessible at `pihole.<domain>/admin`
- [ ] Point a device's DNS to the Pi's IP and confirm ads are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)