### PR TITLE
Add docker-compose for it-tools service

### DIFF
--- a/services/it-tools/docker-compose.yml
+++ b/services/it-tools/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - sqlbak.start.first=false
       - com.centurylinklabs.watchtower.enable=true
       - traefik.enable=true
-      - traefik.http.routers.it-tools.rule=Host(`it-tools.${MY_DOMAIN}`)
+      - traefik.http.routers.it-tools.rule=Host(`it-tools.${USER_DOMAIN}`)
       - traefik.http.routers.it-tools.entryPoints=websecure
       - traefik.http.routers.it-tools.tls=true
       - traefik.http.routers.it-tools.tls.certResolver=le

--- a/services/it-tools/docker-compose.yml
+++ b/services/it-tools/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  it-tools:
+    image: ghcr.io/corentinth/it-tools:latest
+    container_name: it-tools
+    hostname: it-tools
+    networks:
+      - traefik
+    ports:
+      - 8080:80
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.it-tools.rule=Host(`it-tools.${MY_DOMAIN}`)
+      - traefik.http.routers.it-tools.entryPoints=websecure
+      - traefik.http.routers.it-tools.tls=true
+      - traefik.http.routers.it-tools.tls.certResolver=le
+      - traefik.http.services.it-tools.loadBalancer.server.port=80
+    environment:
+      - TZ=America/Sao_Paulo
+      - PUID=${USER_ID}
+      - PGID=${GROUP_ID}
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary

- Adds `services/it-tools/docker-compose.yml` for [IT-Tools](https://github.com/CorentinTh/it-tools), a collection of handy online tools for developers
- Exposes web UI on port 8080 (internal port 80) with Traefik routing via `it-tools.${MY_DOMAIN}`
- Stateless app — no volumes required

## Test plan

- [ ] Run `docker compose up -d` in `services/it-tools/`
- [ ] Verify web UI is accessible at `it-tools.<domain>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)