### PR TITLE
Add PyLoad event scripts with Apprise notifications

### DIFF
--- a/scripts/export_vars.sh
+++ b/scripts/export_vars.sh
@@ -287,6 +287,27 @@ else
     echo "$variable_name_sickchill_token is already set!";
 fi
 
+# ── PyLoad ────────────────────────────────────────────────────────────────────
+
+echo ""
+variable_name_pyload_notification=PYLOAD_NOTIFICATION
+if [ -z ${PYLOAD_NOTIFICATION+x} ]; then
+    echo "$variable_name_pyload_notification is unset";
+    echo "configure now..."
+
+    echo "Enter variable value for $variable_name_pyload_notification:"
+    read variable_value_pyload_notification
+
+    echo ""
+    echo "adding " $variable_name_pyload_notification " to environment variables..."
+    sudo echo "export "$variable_name_pyload_notification"="$variable_value_pyload_notification >> ~/.bashrc
+    sudo echo $variable_name_pyload_notification"="$variable_value_pyload_notification >> ~/.profile
+    echo $variable_name_pyload_notification"="$variable_value_pyload_notification | sudo tee -a /etc/environment
+    restart=true
+else
+    echo "$variable_name_pyload_notification is already set!";
+fi
+
 # ── Derived variables (computed automatically, no user input needed) ───────────
 
 _USERNAME="${variable_value_username:-$USERNAME}"

--- a/services/pyload/docker-compose.yml
+++ b/services/pyload/docker-compose.yml
@@ -21,8 +21,10 @@ services:
       - TZ=America/Sao_Paulo
       - PUID=${USER_ID}
       - PGID=${GROUP_ID}
+      - PYLOAD_NOTIFICATION=${PYLOAD_NOTIFICATION}
     volumes:
       - /home/pi/centerMedia/SupportApps/pyload/config:/config
+      - ./scripts:/config/scripts
       - /home/pi/downloads/pyload:/downloads
     restart: unless-stopped
 

--- a/services/pyload/scripts/after_reconnect/after_reconnect.sh
+++ b/services/pyload/scripts/after_reconnect/after_reconnect.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "after_reconnect" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] after_reconnect", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/all_archives_extracted/all_archives_extracted.sh
+++ b/services/pyload/scripts/all_archives_extracted/all_archives_extracted.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "all_archives_extracted" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] all_archives_extracted", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/all_archives_processed/all_archives_processed.sh
+++ b/services/pyload/scripts/all_archives_processed/all_archives_processed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "all_archives_processed" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] all_archives_processed", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/all_downloads_finished/all_downloads_finished.sh
+++ b/services/pyload/scripts/all_downloads_finished/all_downloads_finished.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "all_downloads_finished" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] all_downloads_finished", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/all_downloads_processed/all_downloads_processed.sh
+++ b/services/pyload/scripts/all_downloads_processed/all_downloads_processed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "all_downloads_processed" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] all_downloads_processed", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/archive_extract_failed/archive_extract_failed.sh
+++ b/services/pyload/scripts/archive_extract_failed/archive_extract_failed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "archive_extract_failed" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] File Error Extracted", "body":"'"Error ao descompactar arquivo $2"'"}'

--- a/services/pyload/scripts/archive_extracted/archive_extracted.sh
+++ b/services/pyload/scripts/archive_extracted/archive_extracted.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "archive_extracted" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] File Success Extracted", "body":"'"Sucesso ao descompactar arquivo $2"'"}'

--- a/services/pyload/scripts/archive_processed/archive_processed.sh
+++ b/services/pyload/scripts/archive_processed/archive_processed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "archive_processed" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] archive_processed", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/before_reconnect/before_reconnect.sh
+++ b/services/pyload/scripts/before_reconnect/before_reconnect.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "before_reconnect" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] before_reconnect", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/download_failed/download_failed.sh
+++ b/services/pyload/scripts/download_failed/download_failed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "download_failed" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] download_failed", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/download_finished/download_finished.sh
+++ b/services/pyload/scripts/download_finished/download_finished.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "download_finished" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] Download Finished", "body":"'"Download do arquivo $2 finalizado com sucesso"'"}'

--- a/services/pyload/scripts/download_preparing/download_preparing.sh
+++ b/services/pyload/scripts/download_preparing/download_preparing.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "download_preparing" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] download_preparing", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/download_processed/download_processed.sh
+++ b/services/pyload/scripts/download_processed/download_processed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "download_processed" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] download_processed", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/package_deleted/package_deleted.sh
+++ b/services/pyload/scripts/package_deleted/package_deleted.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "package_deleted" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] package_deleted", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/package_extract_failed/package_extract_failed.sh
+++ b/services/pyload/scripts/package_extract_failed/package_extract_failed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "package_extract_failed" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] package_extract_failed", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/package_extracted/package_extracted.sh
+++ b/services/pyload/scripts/package_extracted/package_extracted.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "package_extracted" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] package_extracted", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/package_failed/package_failed.sh
+++ b/services/pyload/scripts/package_failed/package_failed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "package_failed" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] package_failed", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/package_finished/package_finished.sh
+++ b/services/pyload/scripts/package_finished/package_finished.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "package_finished" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] package_finished", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/package_processed/package_processed.sh
+++ b/services/pyload/scripts/package_processed/package_processed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "package_processed" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] package_processed", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/pyload_restart/pyload_restart.sh
+++ b/services/pyload/scripts/pyload_restart/pyload_restart.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "pyload_restart" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] pyload_restart", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/pyload_start/pyload_start.sh
+++ b/services/pyload/scripts/pyload_start/pyload_start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "pyload_start" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] pyload_start", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'

--- a/services/pyload/scripts/pyload_stop/pyload_stop.sh
+++ b/services/pyload/scripts/pyload_stop/pyload_stop.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "pyload_stop" $1 $2 $3 $4 $5 $6
+
+curl http://apprise:9000/notify/${PYLOAD_NOTIFICATION} \
+     -H "Content-Type: application/json" \
+     -d '{ "title":"[PYLOAD] pyload_stop", "body":"'"$1 - $2 - $3 - $4 - $5 - $6"'"}'


### PR DESCRIPTION
## Summary

- Add 22 PyLoad event hook scripts organized in per-event subfolders under `services/pyload/scripts/`
- Replace hardcoded Apprise token with `$PYLOAD_NOTIFICATION` environment variable
- Mount scripts folder as nested volume at `/config/scripts` inside the pyload container
- Pass `PYLOAD_NOTIFICATION` into the container via docker-compose `environment`
- Add `PYLOAD_NOTIFICATION` variable setup to `scripts/export_vars.sh`

## Test plan

- [ ] Run `export_vars.sh` and confirm `PYLOAD_NOTIFICATION` prompt appears and is saved
- [ ] Recreate pyload container and verify scripts appear at `/config/scripts/` inside the container
- [ ] Confirm `$PYLOAD_NOTIFICATION` is available inside the container (`docker exec pyload env | grep PYLOAD`)
- [ ] Trigger a download in PyLoad and verify Apprise notification is received

🤖 Generated with [Claude Code](https://claude.com/claude-code)