### PR TITLE
Add SqlBak service with Dockerfile and hook scripts

### DIFF
--- a/services/sqlbak/Dockerfile
+++ b/services/sqlbak/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    docker.io \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -o /tmp/sqlbak.deb https://sqlbak.com/download/linux/latest/sqlbak_arm64.deb \
+    && apt-get install -y /tmp/sqlbak.deb \
+    && rm /tmp/sqlbak.deb
+
+RUN touch /usr/bin/mysql \
+    && chown root:root /usr/bin/mysql \
+    && chmod +x /usr/bin/mysql
+
+COPY scripts/ /home/pi/scripts/
+RUN chmod +x /home/pi/scripts/*.sh
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/services/sqlbak/docker-compose.yml
+++ b/services/sqlbak/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  sqlbak:
+    build: .
+    image: sqlbak-local:latest
+    container_name: sqlbak
+    hostname: sqlbak
+    networks:
+      - traefik
+    labels:
+      - sqlbak.stop.first=false
+      - sqlbak.start.first=true
+      - com.centurylinklabs.watchtower.enable=false
+    environment:
+      - TZ=America/Sao_Paulo
+      - SQLBAK_TOKEN=${SQLBAK_TOKEN}
+      - SQLBAK_SERVER_NAME=pi
+      - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
+      - BOT_TELEGRAM_TOKEN=${BOT_TELEGRAM_TOKEN}
+    volumes:
+      - /home/pi/centerMedia/SupportApps/sqlbak/data:/var/lib/sqlbak
+      - /home/pi/backups:/home/pi/backups
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./scripts:/home/pi/scripts:ro
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik

--- a/services/sqlbak/entrypoint.sh
+++ b/services/sqlbak/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+REGISTERED_FLAG="/var/lib/sqlbak/.registered"
+
+if [ ! -f "$REGISTERED_FLAG" ]; then
+    echo "[sqlbak] Registering server..."
+    sqlbak -r -k "$SQLBAK_TOKEN" -n "${SQLBAK_SERVER_NAME:-pi}"
+
+    echo "[sqlbak] Creating default connection..."
+    sqlbak --add-connection --db-type=mysql --user=root
+
+    mkdir -p "$(dirname "$REGISTERED_FLAG")"
+    touch "$REGISTERED_FLAG"
+fi
+
+echo "[sqlbak] Starting agent..."
+exec sqlbak --agent

--- a/services/sqlbak/scripts/sql-bak_after-script_start-services.sh
+++ b/services/sqlbak/scripts/sql-bak_after-script_start-services.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+#
+# FILE LOCATION: $HOME/scripts/sql-backup_after-script_start-services.sh
+#
+# TURN EXEC: chmod +x $HOME/scripts/sql-backup_after-script.sh
+#
+# To be used in https://sqlbak.com in AFTER SCRIPT session
+#
+# loop through all containers source: https://gist.github.com/robsonke/c5c478bae476adb32d48
+#
+
+send_message()
+{
+    curl -X POST \
+        -H 'Content-Type: application/json' \
+        -d '{"chat_id": "'$TELEGRAM_CHAT_ID'", "text": "<code>'"$1"'</code>", "parse_mode": "HTML", "disable_notification": true}' \
+        https://api.telegram.org/$BOT_TELEGRAM_TOKEN/sendMessage
+}
+
+send_message "[SQL-BAK][AFTER ] Start services..."
+
+###### start first essencial containers
+###### after start containers that depends from other containers
+
+# get all docker container labeled sqlbak.start.first=true
+start_first=$(docker ps -a --filter "label=sqlbak.start.first=true" --format "{{.Names}}")
+send_message "[SQL-BAK][AFTER ] Starting first containers: $start_first ..."
+docker start $start_first
+
+sleep 30
+
+# get all docker container labeled sqlbak.start.first=false
+start_later=$(docker ps -a --filter "label=sqlbak.start.first=false" --format "{{.Names}}")
+send_message "[SQL-BAK][AFTER ] Starting later containers: $start_later ..."
+docker start $start_later
+
+sleep 5
+
+send_message "[SQL-BAK][AFTER ] Starting Plex Media Server..."
+sudo service plexmediaserver start

--- a/services/sqlbak/scripts/sql-bak_after-script_update-services.sh
+++ b/services/sqlbak/scripts/sql-bak_after-script_update-services.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+#
+# FILE LOCATION: $HOME/scripts/sql-bak_after-script_update-services.sh
+#
+# TURN EXEC: chmod +x $HOME/scripts/sql-bak_after-script_update-services.sh
+#
+# To be used in https://sqlbak.com in AFTER SCRIPT session
+#
+# loop through all containers source: https://gist.github.com/robsonke/c5c478bae476adb32d48
+#
+
+echo "[SQL-BAK][AFTER ] Check apt update..."
+sudo apt update
+
+listuptd=""
+for pkg in $(apt list --upgradable 2>/dev/null | awk -F/ 'NR>1 {print $1}'); do
+  listuptd="$listuptd\n- $pkg"
+done
+
+#curl http://192.168.10.100:9000/notify/465a67f962121ed2e5f0e6b55c3a75292903c1dbd5ba9bb5d0a85f0aa27ee6d2 \
+#  -H "Content-Type: application/json" \
+#  -d '{ "title":"[SQL-BAK][AFTER ] Apps to update", "body":"'"execute manually: $listuptd"'"}'
+
+sleep 3
+
+## TODO create script to update all upgradable apt list, included docker service, because all containers are stopped.
+
+echo "[SQL-BAK][AFTER ] Updating Plex Media Server..."
+sudo apt -y install plexmediaserver
+sleep 3
+
+# Limpa cache do apt
+sudo apt clean
+sudo apt autoclean
+sudo apt autoremove
+
+# Limpa logs do systemd (mantém os últimos 100MB)
+sudo journalctl --vacuum-size=100M

--- a/services/sqlbak/scripts/sql-bak_before-script.sh
+++ b/services/sqlbak/scripts/sql-bak_before-script.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+#
+# FILE LOCATION: $HOME/scripts/sql-backup_before-script.sh
+#
+# TURN EXEC: chmod +x $HOME/scripts/sql-backup_before-script.sh
+#
+# To be used in https://sqlbak.com in BEFORE SCRIPT session
+#
+
+send_message()
+{
+    curl -X POST \
+        -H 'Content-Type: application/json' \
+        -d '{"chat_id": "'$TELEGRAM_CHAT_ID'", "text": "<code>'"$1"'</code>", "parse_mode": "HTML", "disable_notification": true}' \
+        https://api.telegram.org/$BOT_TELEGRAM_TOKEN/sendMessage
+}
+
+send_message "[SQL-BAK][BEFORE] Backup process started..."
+
+###### stop first containers that not depend from other containers
+###### after stop essencial containers
+
+# get all docker container labeled sqlbak.stop.first=true
+stop_first=$(docker ps -a --filter "label=sqlbak.stop.first=true" --format "{{.Names}}")
+send_message "[SQL-BAK][BEFORE] Stoping first containers: $stop_first ..."
+docker stop $stop_first
+
+sleep 10
+
+# get all docker container labeled sqlbak.stop.first=false
+stop_later=$(docker ps -a --filter "label=sqlbak.stop.first=false" --format "{{.Names}}")
+send_message "[SQL-BAK][BEFORE] Stoping later containers: $stop_later ..."
+docker stop $stop_later
+
+sleep 5
+
+# Stop plex
+send_message "[SQL-BAK][BEFORE] Stoping Plex Media Server..."
+sudo service plexmediaserver stop
+
+sleep 5
+
+send_message "[SQL-BAK][BEFORE] Backuping some files..."
+dpkg --get-selections > $HOME/backups/rasp_pi/Package.list
+sudo cp -R /etc/apt/sources.list* $HOME/backups/rasp_pi/
+sudo apt-key exportall > $HOME/backups/rasp_pi/Repo.keys
+
+send_message "[SQL-BAK] Backup will be start..."


### PR DESCRIPTION
## Summary

- Add `Dockerfile` that installs `sqlbak_arm64.deb` and creates a mysql mock at `/usr/bin/mysql`
- Add `entrypoint.sh` that registers the server once (guarded by a flag file) and starts the SqlBak agent
- Add `docker-compose.yml` with Docker socket mount, required env vars (`SQLBAK_TOKEN`, `TELEGRAM_CHAT_ID`, `BOT_TELEGRAM_TOKEN`) and volume for persistent registration state
- Copy the 3 SqlBak hook scripts into `services/sqlbak/scripts/` for use inside the container
- Original scripts in `scripts/` kept untouched for backwards compatibility

## ⚠️ Known limitation

The hook scripts call `sudo service plexmediaserver stop/start` which controls a host systemd service — this will not work from inside the container. Docker `stop/start` commands will work normally via the mounted Docker socket.

## Test plan

- [ ] `docker compose build` completes without errors
- [ ] On first `docker compose up`, container registers with SqlBak and creates the flag file
- [ ] On subsequent restarts, registration is skipped (flag file exists)
- [ ] Hook scripts are accessible at `/home/pi/scripts/` inside the container
- [ ] `$PYLOAD_NOTIFICATION`, `$TELEGRAM_CHAT_ID`, `$BOT_TELEGRAM_TOKEN` are available inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)