### PR TITLE
Add docker-compose for portainer-ce service

### DIFF
--- a/services/portainer-ce/docker-compose.yml
+++ b/services/portainer-ce/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  portainer-ce:
+    image: portainer/portainer-ce:latest
+    container_name: portainer-ce
+    hostname: portainer-ce
+    networks:
+      - traefik
+    ports:
+      - 9000:9000
+      - 8000:8000
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.portainer-ce.rule=Host(`portainer.${USER_DOMAIN}`)
+      - traefik.http.routers.portainer-ce.entryPoints=websecure
+      - traefik.http.routers.portainer-ce.tls=true
+      - traefik.http.routers.portainer-ce.tls.certResolver=le
+      - traefik.http.services.portainer-ce.loadBalancer.server.port=9000
+    environment:
+      - TZ=America/Sao_Paulo
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /home/pi/centerMedia/SupportApps/portainer-ce/data:/data
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary
- Adds `services/portainer-ce/docker-compose.yml` for Portainer CE container management UI
- Exposes port 9000 (HTTP) for Traefik routing and port 8000 for Edge agent tunnel
- Routed via Traefik at `portainer.${USER_DOMAIN}` with TLS
- Data persisted at `/home/pi/centerMedia/SupportApps/portainer-ce/data`

## Test plan
- [ ] Run `docker compose up -d` in `services/portainer-ce/`
- [ ] Verify Portainer UI is accessible at `https://portainer.<domain>`
- [ ] Confirm `/var/run/docker.sock` is correctly mounted (Portainer can list containers)
- [ ] Verify data volume is created at the expected host path

🤖 Generated with [Claude Code](https://claude.com/claude-code)