### PR TITLE
Add docker-compose for uptime-kuma service

### DIFF
--- a/services/uptime-kuma/docker-compose.yml
+++ b/services/uptime-kuma/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:nightly2
+    container_name: uptime-kuma
+    hostname: uptime-kuma
+    networks:
+      - traefik
+    ports:
+      - 3001:3001
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.uptime-kuma.rule=Host(`uptime-kuma.${USER_DOMAIN}`)
+      - traefik.http.routers.uptime-kuma.entryPoints=websecure
+      - traefik.http.routers.uptime-kuma.tls=true
+      - traefik.http.routers.uptime-kuma.tls.certResolver=le
+      - traefik.http.services.uptime-kuma.loadBalancer.server.port=3001
+    environment:
+      - TZ=America/Sao_Paulo
+    volumes:
+      - /home/pi/centerMedia/SupportApps/uptime-kuma/data:/app/data
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary
- Adds `services/uptime-kuma/docker-compose.yml` for Uptime Kuma monitoring/status page service
- Exposes port 3001 for web UI, routed via Traefik at `uptime-kuma.${USER_DOMAIN}` with TLS
- Data persisted at `/home/pi/centerMedia/SupportApps/uptime-kuma/data`

## Test plan
- [ ] Run `docker compose up -d` in `services/uptime-kuma/`
- [ ] Verify Uptime Kuma UI is accessible at `https://uptime-kuma.<domain>`
- [ ] Complete initial setup (create admin account on first run)
- [ ] Add a monitor and verify status tracking works

🤖 Generated with [Claude Code](https://claude.com/claude-code)