### PR TITLE
Add docker-compose for dozzle service

### DIFF
--- a/services/dozzle/docker-compose.yml
+++ b/services/dozzle/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    container_name: dozzle
+    hostname: dozzle
+    networks:
+      - traefik
+    ports:
+      - 8080:8080
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.dozzle.rule=Host(`dozzle.${USER_DOMAIN}`)
+      - traefik.http.routers.dozzle.entryPoints=websecure
+      - traefik.http.routers.dozzle.tls=true
+      - traefik.http.routers.dozzle.tls.certResolver=le
+      - traefik.http.services.dozzle.loadBalancer.server.port=8080
+    environment:
+      - TZ=America/Sao_Paulo
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary
- Adds `services/dozzle/docker-compose.yml` for Dozzle — real-time Docker container log viewer
- Exposes port 8080 for web UI, routed via Traefik at `dozzle.${USER_DOMAIN}` with TLS
- Mounts `/var/run/docker.sock` for Docker daemon access

## Test plan
- [ ] Run `docker compose up -d` in `services/dozzle/`
- [ ] Verify Dozzle UI is accessible at `https://dozzle.<domain>`
- [ ] Confirm container list loads and logs stream correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)