### PR TITLE
Add OpenVPN service with CDP proxy and multiple country configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ Temporary Items
 # Intelij
 .idea
 
+
+# Arquivos sensíveis — nunca commitar
+.env
+credentials.txt

--- a/services/openvpn/.gitignore
+++ b/services/openvpn/.gitignore
@@ -1,0 +1,2 @@
+.env
+credentials.txt

--- a/services/openvpn/.gitignore
+++ b/services/openvpn/.gitignore
@@ -1,2 +1,0 @@
-.env
-credentials.txt

--- a/services/openvpn/Dockerfile
+++ b/services/openvpn/Dockerfile
@@ -3,12 +3,9 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y \
     openvpn \
     chromium \
-    chromium-driver \
-    dnsutils \
     curl \
     socat \
     iproute2 \
-    iptables \
     && rm -rf /var/lib/apt/lists/*
 
 # Cria diretório para configs
@@ -18,6 +15,6 @@ RUN mkdir -p /etc/openvpn/configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-EXPOSE 18800
+EXPOSE 18801
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/services/openvpn/Dockerfile
+++ b/services/openvpn/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    openvpn \
+    chromium \
+    chromium-driver \
+    dnsutils \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Cria diretório para configs
+RUN mkdir -p /etc/openvpn/configs
+
+# Script de entrypoint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 18800
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/services/openvpn/Dockerfile
+++ b/services/openvpn/Dockerfile
@@ -6,6 +6,9 @@ RUN apt-get update && apt-get install -y \
     chromium-driver \
     dnsutils \
     curl \
+    socat \
+    iproute2 \
+    iptables \
     && rm -rf /var/lib/apt/lists/*
 
 # Cria diretório para configs

--- a/services/openvpn/build.sh
+++ b/services/openvpn/build.sh
@@ -2,7 +2,7 @@
 # Rebuild da imagem openvpn+chromium
 set -e
 
-cd /home/pi/media-server-pi-config/services/openvpn
+cd "$(cd "$(dirname "$0")" && pwd)"
 echo "Building openvpn container..."
 docker compose build
 echo "Build concluido!"

--- a/services/openvpn/build.sh
+++ b/services/openvpn/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Rebuild da imagem openvpn+chromium
+set -e
+
+cd /home/pi/media-server-pi-config/services/openvpn
+echo "Building openvpn container..."
+docker compose build
+echo "Build concluido!"

--- a/services/openvpn/docker-compose.yml
+++ b/services/openvpn/docker-compose.yml
@@ -3,13 +3,15 @@ services:
     build: .
     container_name: openvpn
     hostname: openvpn
+    # restart: "no" é intencional — este container é iniciado sob demanda pelo script
+    # soundtrack_hotlink_resolver.py e não deve reiniciar automaticamente
     restart: "no"
     cap_add:
       - NET_ADMIN      # necessário para OpenVPN criar interface tun
     devices:
       - /dev/net/tun   # necessário para OpenVPN
     ports:
-      - "18801:18801"  # CDP proxy — acessível pelo Pi 5 em 192.168.10.100:18801
+      - "192.168.10.100:18801:18801"  # CDP proxy — acessível pelo Pi 5 (192.168.10.150)
     volumes:
       - ./ovpn_configs:/etc/openvpn/configs:ro
     environment:

--- a/services/openvpn/docker-compose.yml
+++ b/services/openvpn/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  openvpn:
+    build: .
+    container_name: openvpn
+    hostname: openvpn
+    cap_add:
+      - NET_ADMIN      # necessário para OpenVPN criar interface tun
+    devices:
+      - /dev/net/tun   # necessário para OpenVPN
+    ports:
+      - "18800:18800"  # CDP do Chromium — acessível pelo Pi 5 em 192.168.10.100:18800
+    volumes:
+      - ./ovpn_configs:/etc/openvpn/configs:ro
+    environment:
+      - TZ=America/Sao_Paulo
+      - VPN_USER=${VPN_USER}
+      - VPN_PASS=${VPN_PASS}

--- a/services/openvpn/docker-compose.yml
+++ b/services/openvpn/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     container_name: openvpn
     hostname: openvpn
+    restart: "no"
     cap_add:
       - NET_ADMIN      # necessário para OpenVPN criar interface tun
     devices:
@@ -15,3 +16,4 @@ services:
       - TZ=America/Sao_Paulo
       - VPN_USER=${VPN_USER}
       - VPN_PASS=${VPN_PASS}
+      - VPN_COUNTRY=${VPN_COUNTRY:-}  # opcional — se vazio, escolhe país aleatório

--- a/services/openvpn/docker-compose.yml
+++ b/services/openvpn/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     devices:
       - /dev/net/tun   # necessário para OpenVPN
     ports:
-      - "18800:18800"  # CDP do Chromium — acessível pelo Pi 5 em 192.168.10.100:18800
+      - "18801:18801"  # CDP proxy — acessível pelo Pi 5 em 192.168.10.100:18801
     volumes:
       - ./ovpn_configs:/etc/openvpn/configs:ro
     environment:

--- a/services/openvpn/entrypoint.sh
+++ b/services/openvpn/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Entrypoint: gera credentials.txt a partir de env vars e inicia Chromium headless
+
+# Gera credentials.txt dinamicamente
+if [ -n "$VPN_USER" ] && [ -n "$VPN_PASS" ]; then
+    echo "$VPN_USER" > /etc/openvpn/credentials.txt
+    echo "$VPN_PASS" >> /etc/openvpn/credentials.txt
+    chmod 600 /etc/openvpn/credentials.txt
+    echo "Credenciais VPN configuradas"
+else
+    echo "ERRO: VPN_USER e VPN_PASS devem ser definidos" >&2
+    exit 1
+fi
+
+# Inicia Chromium headless em background
+chromium \
+  --headless \
+  --no-sandbox \
+  --disable-gpu \
+  --disable-dev-shm-usage \
+  --remote-debugging-port=18800 \
+  --remote-debugging-address=0.0.0.0 \
+  --disable-web-security \
+  2>/dev/null &
+
+echo "Chromium iniciado (PID $!)"
+echo "CDP disponível em :18800"
+
+# Mantém container vivo
+tail -f /dev/null

--- a/services/openvpn/entrypoint.sh
+++ b/services/openvpn/entrypoint.sh
@@ -29,16 +29,17 @@ fi
 
 echo "Conectando VPN: $OVPN_FILE"
 
-# Conecta OpenVPN em foreground temporariamente para aguardar conexão
 openvpn --config "$OVPN_FILE" \
         --auth-user-pass /etc/openvpn/credentials.txt \
         --log /tmp/vpn.log \
         --daemon
 
-# Aguarda conexão estabelecer
+# Aguarda conexão estabelecer — falha explicitamente se não conectar em 20s
 echo "Aguardando VPN conectar..."
+VPN_CONNECTED=0
 for i in $(seq 1 20); do
     if grep -q "Initialization Sequence Completed" /tmp/vpn.log 2>/dev/null; then
+        VPN_CONNECTED=1
         echo "VPN conectada! IP externo:"
         curl -s --max-time 5 https://api.my-ip.io/v2/ip.json | grep -o '"ip":"[^"]*"' | cut -d'"' -f4
         break
@@ -50,32 +51,54 @@ for i in $(seq 1 20); do
     sleep 1
 done
 
-# Garante que tráfego de retorno para a rede local (192.168.10.0/24) 
-# vai pela interface eth0, não pelo túnel VPN
-# Isso permite que o Pi 5 (192.168.10.150) alcance o CDP do container
-ip route add 192.168.10.0/24 via $(ip route | grep 'default.*eth0' | awk '{print $3}') dev eth0 2>/dev/null || true
-echo "Rota local adicionada"
+if [ "$VPN_CONNECTED" -eq 0 ]; then
+    echo "ERRO: VPN não conectou em 20 segundos" >&2
+    exit 1
+fi
 
-# Inicia Chromium headless em background
+# Garante que tráfego de retorno para a rede local vai pela eth0, não pelo túnel VPN
+# Isso permite que o Pi 5 (192.168.10.150) alcance o CDP do container
+LOCAL_GW=$(ip route | awk '/default .*eth0/ {print $3; exit}')
+if [ -n "$LOCAL_GW" ]; then
+    if ip route add 192.168.10.0/24 via "$LOCAL_GW" dev eth0 2>/dev/null; then
+        echo "Rota local adicionada"
+    else
+        echo "AVISO: falha ao adicionar rota local via $LOCAL_GW" >&2
+    fi
+else
+    echo "AVISO: gateway padrão na eth0 não encontrado; rota local não adicionada" >&2
+fi
+
+# Inicia Chromium headless — bind em localhost (socat expõe externamente na 18801)
 chromium \
   --headless \
   --no-sandbox \
   --disable-gpu \
   --disable-dev-shm-usage \
   --remote-debugging-port=18800 \
-  --remote-debugging-address=0.0.0.0 \
+  --remote-debugging-address=127.0.0.1 \
   --disable-web-security \
   --remote-allow-origins=* \
   2>/dev/null &
 
-echo "Chromium iniciado (PID $!)"
+CHROMIUM_PID=$!
+echo "Chromium iniciado (PID ${CHROMIUM_PID})"
 
 # Aguarda Chromium iniciar
 sleep 3
 
 # Proxy TCP: redireciona 0.0.0.0:18801 -> 127.0.0.1:18800
 socat TCP-LISTEN:18801,fork,reuseaddr TCP:127.0.0.1:18800 &
-echo "Proxy CDP disponível em :18801 (externo) -> :18800 (Chromium)"
+SOCAT_PID=$!
+echo "Proxy CDP disponível em :18801 (externo) -> :18800 (Chromium) (PID ${SOCAT_PID})"
 
-# Mantém container vivo
-tail -f /dev/null
+# Trata sinais para encerrar processos filho corretamente
+shutdown() {
+    echo "Recebido sinal, encerrando serviços..."
+    kill "${SOCAT_PID}" 2>/dev/null || true
+    kill "${CHROMIUM_PID}" 2>/dev/null || true
+}
+trap 'shutdown' SIGTERM SIGINT
+
+# Mantém container vivo aguardando processos principais
+wait "${CHROMIUM_PID}" "${SOCAT_PID}"

--- a/services/openvpn/entrypoint.sh
+++ b/services/openvpn/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Entrypoint: gera credentials.txt a partir de env vars e inicia Chromium headless
+# Entrypoint: conecta VPN, inicia Chromium headless e proxy TCP
+
+set -e
 
 # Gera credentials.txt dinamicamente
 if [ -n "$VPN_USER" ] && [ -n "$VPN_PASS" ]; then
@@ -12,6 +14,48 @@ else
     exit 1
 fi
 
+# Seleciona arquivo .ovpn — usa VPN_COUNTRY se definido, senão escolhe aleatório
+OVPN_DIR="/etc/openvpn/configs"
+if [ -n "$VPN_COUNTRY" ]; then
+    OVPN_FILE=$(ls ${OVPN_DIR}/${VPN_COUNTRY}*.ovpn 2>/dev/null | head -1)
+else
+    OVPN_FILE=$(ls ${OVPN_DIR}/*.ovpn | shuf -n 1)
+fi
+
+if [ -z "$OVPN_FILE" ]; then
+    echo "ERRO: Nenhum arquivo .ovpn encontrado em $OVPN_DIR" >&2
+    exit 1
+fi
+
+echo "Conectando VPN: $OVPN_FILE"
+
+# Conecta OpenVPN em foreground temporariamente para aguardar conexão
+openvpn --config "$OVPN_FILE" \
+        --auth-user-pass /etc/openvpn/credentials.txt \
+        --log /tmp/vpn.log \
+        --daemon
+
+# Aguarda conexão estabelecer
+echo "Aguardando VPN conectar..."
+for i in $(seq 1 20); do
+    if grep -q "Initialization Sequence Completed" /tmp/vpn.log 2>/dev/null; then
+        echo "VPN conectada! IP externo:"
+        curl -s --max-time 5 https://api.my-ip.io/v2/ip.json | grep -o '"ip":"[^"]*"' | cut -d'"' -f4
+        break
+    fi
+    if grep -q "AUTH_FAILED\|TLS Error" /tmp/vpn.log 2>/dev/null; then
+        echo "ERRO: Falha de autenticação VPN" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+# Garante que tráfego de retorno para a rede local (192.168.10.0/24) 
+# vai pela interface eth0, não pelo túnel VPN
+# Isso permite que o Pi 5 (192.168.10.150) alcance o CDP do container
+ip route add 192.168.10.0/24 via $(ip route | grep 'default.*eth0' | awk '{print $3}') dev eth0 2>/dev/null || true
+echo "Rota local adicionada"
+
 # Inicia Chromium headless em background
 chromium \
   --headless \
@@ -21,10 +65,17 @@ chromium \
   --remote-debugging-port=18800 \
   --remote-debugging-address=0.0.0.0 \
   --disable-web-security \
+  --remote-allow-origins=* \
   2>/dev/null &
 
 echo "Chromium iniciado (PID $!)"
-echo "CDP disponível em :18800"
+
+# Aguarda Chromium iniciar
+sleep 3
+
+# Proxy TCP: redireciona 0.0.0.0:18801 -> 127.0.0.1:18800
+socat TCP-LISTEN:18801,fork,reuseaddr TCP:127.0.0.1:18800 &
+echo "Proxy CDP disponível em :18801 (externo) -> :18800 (Chromium)"
 
 # Mantém container vivo
 tail -f /dev/null

--- a/services/openvpn/ovpn_configs/ca-free-5.ovpn
+++ b/services/openvpn/ovpn_configs/ca-free-5.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server CA-FREE#5 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through CA-FREE#5.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 149.88.97.122 5060
+remote 149.88.97.122 4569
+remote 149.88.97.122 51820
+remote 149.88.97.122 1194
+remote 149.88.97.122 80
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>

--- a/services/openvpn/ovpn_configs/ch-free-3.ovpn
+++ b/services/openvpn/ovpn_configs/ch-free-3.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server CH-FREE#3 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through CH-FREE#3.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 138.199.6.178 80
+remote 138.199.6.178 5060
+remote 138.199.6.178 51820
+remote 138.199.6.178 4569
+remote 138.199.6.178 1194
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>

--- a/services/openvpn/ovpn_configs/jp-free-23.ovpn
+++ b/services/openvpn/ovpn_configs/jp-free-23.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server JP-FREE#23 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through JP-FREE#23.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 212.102.51.55 80
+remote 212.102.51.55 4569
+remote 212.102.51.55 5060
+remote 212.102.51.55 51820
+remote 212.102.51.55 1194
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>

--- a/services/openvpn/ovpn_configs/mx-free-11.ovpn
+++ b/services/openvpn/ovpn_configs/mx-free-11.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server MX-FREE#11 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through MX-FREE#11.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 84.20.27.48 5060
+remote 84.20.27.48 51820
+remote 84.20.27.48 80
+remote 84.20.27.48 1194
+remote 84.20.27.48 4569
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>

--- a/services/openvpn/ovpn_configs/nl-free-103.ovpn
+++ b/services/openvpn/ovpn_configs/nl-free-103.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server NL-FREE#103 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through NL-FREE#103.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 212.8.253.154 1194
+remote 212.8.253.154 5060
+remote 212.8.253.154 51820
+remote 212.8.253.154 4569
+remote 212.8.253.154 80
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>

--- a/services/openvpn/ovpn_configs/no-free-6.ovpn
+++ b/services/openvpn/ovpn_configs/no-free-6.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server NO-FREE#6 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through NO-FREE#6.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 95.173.205.165 51820
+remote 95.173.205.165 4569
+remote 95.173.205.165 5060
+remote 95.173.205.165 80
+remote 95.173.205.165 1194
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>

--- a/services/openvpn/ovpn_configs/pl-free-13.ovpn
+++ b/services/openvpn/ovpn_configs/pl-free-13.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server PL-FREE#13 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through PL-FREE#13.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 149.102.244.112 51820
+remote 149.102.244.112 5060
+remote 149.102.244.112 80
+remote 149.102.244.112 1194
+remote 149.102.244.112 4569
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>

--- a/services/openvpn/ovpn_configs/ro-free-24.ovpn
+++ b/services/openvpn/ovpn_configs/ro-free-24.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server RO-FREE#24 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through RO-FREE#24.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 146.70.246.114 51820
+remote 146.70.246.114 1194
+remote 146.70.246.114 4569
+remote 146.70.246.114 5060
+remote 146.70.246.114 80
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>

--- a/services/openvpn/ovpn_configs/sg-free-14.ovpn
+++ b/services/openvpn/ovpn_configs/sg-free-14.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server SG-FREE#14 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through SG-FREE#14.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 103.216.221.68 4569
+remote 103.216.221.68 5060
+remote 103.216.221.68 51820
+remote 103.216.221.68 80
+remote 103.216.221.68 1194
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>

--- a/services/openvpn/ovpn_configs/us-free-34.ovpn
+++ b/services/openvpn/ovpn_configs/us-free-34.ovpn
@@ -1,0 +1,125 @@
+# ==============================================================================
+# Copyright (c) 2023 Proton AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+# The server you are connecting to is using a circuit in order to separate entry IP from exit IP
+# The same entry IP allows to connect to multiple exit IPs in the same data center.
+
+# If you want to explicitly select the exit IP corresponding to server US-FREE#34 you need to
+# append a special suffix to your OpenVPN username.
+# Please use "QTZTtW1hNBP6Qzu6+b:0" in order to enforce exiting through US-FREE#34.
+
+# If you are a paying user you can also enable the ProtonVPN ad blocker (NetShield) or Moderate NAT:
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f1" to enable anti-malware filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+f2" to additionally enable ad-blocking filtering
+# Use: "QTZTtW1hNBP6Qzu6+b:0+nr" to enable Moderate NAT
+# Note that you can combine the "+nr" suffix with other suffixes.
+
+client
+dev tun
+proto udp
+
+remote 149.102.254.89 1194
+remote 149.102.254.89 4569
+remote 149.102.254.89 51820
+remote 149.102.254.89 5060
+remote 149.102.254.89 80
+
+remote-random
+resolv-retry infinite
+nobind
+
+cipher AES-256-GCM
+
+setenv CLIENT_CERT 0
+tun-mtu 1500
+mssfix 0
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+
+script-security 2
+up /etc/openvpn/update-resolv-conf
+down /etc/openvpn/update-resolv-conf
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFnTCCA4WgAwIBAgIUCI574SM3Lyh47GyNl0WAOYrqb5QwDQYJKoZIhvcNAQEL
+BQAwXjELMAkGA1UEBhMCQ0gxHzAdBgNVBAoMFlByb3RvbiBUZWNobm9sb2dpZXMg
+QUcxEjAQBgNVBAsMCVByb3RvblZQTjEaMBgGA1UEAwwRUHJvdG9uVlBOIFJvb3Qg
+Q0EwHhcNMTkxMDE3MDgwNjQxWhcNMzkxMDEyMDgwNjQxWjBeMQswCQYDVQQGEwJD
+SDEfMB0GA1UECgwWUHJvdG9uIFRlY2hub2xvZ2llcyBBRzESMBAGA1UECwwJUHJv
+dG9uVlBOMRowGAYDVQQDDBFQcm90b25WUE4gUm9vdCBDQTCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMkUT7zMUS5C+NjQ7YoGpVFlfbN9HFgG4JiKfHB8
+QxnPPRgyTi0zVOAj1ImsRilauY8Ddm5dQtd8qcApoz6oCx5cFiiSQG2uyhS/59Zl
+5wqIkw1o+CgwZgeWkq04lcrxhhfPgJZRFjrYVezy/Z2Ssd18s3/FFNQ+2iV1KC2K
+z8eSPr50u+l9vEKsKiNGkJTdlWjoDKZM2C15i/h8Smi+PdJlx7WMTtYoVC1Fzq0r
+aCPDQl18kspu11b6d8ECPWghKcDIIKuA0r0nGqF1GvH1AmbC/xUaNrKgz9AfioZL
+MP/l22tVG3KKM1ku0eYHX7NzNHgkM2JKnBBannImQQBGTAcvvUlnfF3AHx4vzx7H
+ahpBz8ebThx2uv+vzu8lCVEcKjQObGwLbAONJN2enug8hwSSZQv7tz7onDQWlYh0
+El5fnkrEQGbukNnSyOqTwfobvBllIPzBqdO38eZFA0YTlH9plYjIjPjGl931lFAA
+3G9t0x7nxAauLXN5QVp1yoF1tzXc5kN0SFAasM9VtVEOSMaGHLKhF+IMyVX8h5Iu
+IRC8u5O672r7cHS+Dtx87LjxypqNhmbf1TWyLJSoh0qYhMr+BbO7+N6zKRIZPI5b
+MXc8Be2pQwbSA4ZrDvSjFC9yDXmSuZTyVo6Bqi/KCUZeaXKof68oNxVYeGowNeQd
+g/znAgMBAAGjUzBRMB0GA1UdDgQWBBR44WtTuEKCaPPUltYEHZoyhJo+4TAfBgNV
+HSMEGDAWgBR44WtTuEKCaPPUltYEHZoyhJo+4TAPBgNVHRMBAf8EBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4ICAQBBmzCQlHxOJ6izys3TVpaze+rUkA9GejgsB2DZXIcm
+4Lj/SNzQsPlZRu4S0IZV253dbE1DoWlHanw5lnXwx8iU82X7jdm/5uZOwj2NqSqT
+bTn0WLAC6khEKKe5bPTf18UOcwN82Le3AnkwcNAaBO5/TzFQVgnVedXr2g6rmpp9
+gdedeEl9acB7xqfYfkrmijqYMm+xeG2rXaanch3HjweMDuZdT/Ub5G6oir0Kowft
+lA1ytjXRg+X+yWymTpF/zGLYfSodWWjMKhpzZtRJZ+9B0pWXUyY7SuCj5T5SMIAu
+x3NQQ46wSbHRolIlwh7zD7kBgkyLe7ByLvGFKa2Vw4PuWjqYwrRbFjb2+EKAwPu6
+VTWz/QQTU8oJewGFipw94Bi61zuaPvF1qZCHgYhVojRy6KcqncX2Hx9hjfVxspBZ
+DrVH6uofCmd99GmVu+qizybWQTrPaubfc/a2jJIbXc2bRQjYj/qmjE3hTlmO3k7V
+EP6i8CLhEl+dX75aZw9StkqjdpIApYwX6XNDqVuGzfeTXXclk4N4aDPwPFM/Yo/e
+KnvlNlKbljWdMYkfx8r37aOHpchH34cv0Jb5Im+1H07ywnshXNfUhRazOpubJRHn
+bjDuBwWS1/Vwp5AJ+QHsPXhJdl3qHc1szJZVJb3VyAWvG/bWApKfFuZX18tiI4N0
+EA==
+-----END CERTIFICATE-----
+</ca>
+
+<tls-crypt>
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-crypt>


### PR DESCRIPTION
## Summary

- Adds `services/openvpn/` with a custom Docker image for OpenVPN
- `Dockerfile` installs OpenVPN and sets up the `tun` device
- `entrypoint.sh` connects to a VPN server based on `VPN_COUNTRY` env var (random country if empty) using credentials from `VPN_USER`/`VPN_PASS`
- Exposes port 18801 as a CDP proxy accessible from the Pi 5 at `192.168.10.100:18801`
- Includes 10 pre-configured `.ovpn` free server configs (CA, CH, JP, MX, NL, NO, PL, RO, SG, US)
- `build.sh` helper script to build the Docker image

## Test plan

- [ ] Set `VPN_USER`, `VPN_PASS` in the environment
- [ ] Run `./build.sh` to build the image
- [ ] Run `docker compose up` in `services/openvpn/`
- [ ] Verify container connects to VPN and the `tun` interface is created
- [ ] Test CDP proxy at `192.168.10.100:18801`
- [ ] Test `VPN_COUNTRY` selection (e.g. `VPN_COUNTRY=jp` to connect to Japan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)