### PR TITLE
Add docker-compose for beszel service

### DIFF
--- a/services/beszel/docker-compose.yml
+++ b/services/beszel/docker-compose.yml
@@ -22,6 +22,30 @@ services:
       - APP_URL=https://beszel.${USER_DOMAIN}
     volumes:
       - /home/pi/centerMedia/SupportApps/beszel/data:/beszel_data
+      - /home/pi/centerMedia/SupportApps/beszel/socket:/beszel_socket
+    restart: unless-stopped
+
+  beszel-agent:
+    image: henrygd/beszel-agent:latest
+    container_name: beszel-agent
+    hostname: beszel-agent
+    network_mode: host
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+    environment:
+      - TZ=America/Sao_Paulo
+      - LISTEN=/beszel_socket/beszel.sock
+      - HUB_URL=http://localhost:8090
+      # TOKEN and KEY are generated in the Beszel web UI when adding a system.
+      # Fill these in after the first login, then restart the agent.
+      - TOKEN=
+      - KEY=
+    volumes:
+      - /home/pi/centerMedia/SupportApps/beszel/socket:/beszel_socket
+      - /home/pi/centerMedia/SupportApps/beszel/agent-data:/var/lib/beszel-agent
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: unless-stopped
 
 networks:

--- a/services/beszel/docker-compose.yml
+++ b/services/beszel/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  beszel:
+    image: henrygd/beszel:latest
+    container_name: beszel
+    hostname: beszel
+    networks:
+      - traefik
+    ports:
+      - 8090:8090
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.beszel.rule=Host(`beszel.${USER_DOMAIN}`)
+      - traefik.http.routers.beszel.entryPoints=websecure
+      - traefik.http.routers.beszel.tls=true
+      - traefik.http.routers.beszel.tls.certResolver=le
+      - traefik.http.services.beszel.loadBalancer.server.port=8090
+    environment:
+      - TZ=America/Sao_Paulo
+      - APP_URL=https://beszel.${USER_DOMAIN}
+    volumes:
+      - /home/pi/centerMedia/SupportApps/beszel/data:/beszel_data
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary

- Adds `services/beszel/docker-compose.yml` for [Beszel](https://beszel.dev), a lightweight server monitoring hub with web UI
- Exposes port `8090` with Traefik routing at `beszel.${USER_DOMAIN}`
- Persists data to `/home/pi/centerMedia/SupportApps/beszel/data`
- Sets `APP_URL` to the Traefik-managed HTTPS domain

## Test plan

- [ ] Run `docker compose up -d` from `services/beszel/`
- [ ] Access `https://beszel.<domain>` and complete initial setup
- [ ] Verify data persists across container restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)