### PR TITLE
Add docker-compose for ntopng service

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,11 @@
       "WebFetch(domain:hub.docker.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:docs.linuxserver.io)",
-      "WebFetch(domain:docs.portainer.io)"
+      "WebFetch(domain:docs.portainer.io)",
+      "WebFetch(domain:beszel.dev)",
+      "Bash(gh api:*)",
+      "WebFetch(domain:www.ntop.org)",
+      "WebFetch(domain:raw.githubusercontent.com)"
     ]
   }
 }

--- a/services/ntopng/docker-compose.yml
+++ b/services/ntopng/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  ntopng:
+    image: ntop/ntopng:latest
+    container_name: ntopng
+    hostname: ntopng
+    # ntopng requires host networking for network interface monitoring (packet capture)
+    network_mode: host
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.ntopng.rule=Host(`ntopng.${USER_DOMAIN}`)
+      - traefik.http.routers.ntopng.entryPoints=websecure
+      - traefik.http.routers.ntopng.tls=true
+      - traefik.http.routers.ntopng.tls.certResolver=le
+      - traefik.http.services.ntopng.loadBalancer.server.port=3000
+    environment:
+      - TZ=America/Sao_Paulo
+      # Pass ntopng CLI flags via NTOP_CONFIG, e.g.: -i eth0
+      - NTOP_CONFIG=
+    volumes:
+      - /etc/ntopng.license:/etc/ntopng.license:ro
+      - /home/pi/centerMedia/SupportApps/ntopng/data:/var/lib/ntopng
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

- Adds `services/ntopng/docker-compose.yml` for [ntop/ntopng](https://hub.docker.com/r/ntop/ntopng) — a network traffic monitoring and analysis tool
- Uses `network_mode: host` (required for packet capture on network interfaces)
- Web UI exposed on port 3000, with Traefik reverse proxy labels
- Mounts license file (`/etc/ntopng.license`) and persistent data volume

## Notes

- `network_mode: host` is mutually exclusive with Docker named networks, so the `traefik` network block is omitted; Traefik can still proxy to `localhost:3000`
- Set `NTOP_CONFIG` env var to pass CLI flags (e.g., `-i eth0` to select a network interface)
- License file is optional for community edition

## Test plan

- [ ] Run `docker compose up -d` in `services/ntopng/`
- [ ] Verify web UI is accessible on port 3000
- [ ] Confirm Traefik routes `ntopng.${USER_DOMAIN}` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)