### PR TITLE
Add docker-compose for netbird service

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,9 @@
       "WebFetch(domain:hub.docker.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:docs.linuxserver.io)",
-      "WebFetch(domain:docs.portainer.io)"
+      "WebFetch(domain:docs.portainer.io)",
+      "WebFetch(domain:docs.netbird.io)",
+      "Bash(gh api:*)"
     ]
   }
 }

--- a/services/netbird/docker-compose.yml
+++ b/services/netbird/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  netbird:
+    image: netbirdio/netbird:rootless-latest
+    container_name: netbird
+    hostname: netbird
+    networks:
+      - traefik
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+    environment:
+      - TZ=America/Sao_Paulo
+      # Setup key from NetBird dashboard (required on first run to register this peer)
+      - NB_SETUP_KEY=${NETBIRD_SETUP_KEY}
+      # Optional: point to a self-hosted management server
+      # - NB_MANAGEMENT_URL=https://api.wiretrustee.com:443
+    volumes:
+      - /home/pi/centerMedia/SupportApps/netbird/data:/var/lib/netbird
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary

- Adds `services/netbird/docker-compose.yml` for [netbirdio/netbird](https://hub.docker.com/r/netbirdio/netbird) — a WireGuard-based mesh VPN client
- Uses the `rootless-latest` tag which runs as a non-root user via userspace netstack mode (no `--privileged`, no `--network host`, no capabilities required)
- No web UI — pure VPN client, no Traefik labels
- Set `NETBIRD_SETUP_KEY` env var (from NetBird dashboard) to register the peer on first run

## Notes

- Data/config is persisted at `/home/pi/centerMedia/SupportApps/netbird/data`
- To use a self-hosted NetBird management server, uncomment and set `NB_MANAGEMENT_URL`

## Test plan

- [ ] Export `NETBIRD_SETUP_KEY` in environment or `.env` file
- [ ] Run `docker compose up -d` in `services/netbird/`
- [ ] Verify peer appears as connected in the NetBird dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)