### PR TITLE
Add docker-compose for actual-server service

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "WebFetch(domain:hub.docker.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:docs.linuxserver.io)",
-      "WebFetch(domain:docs.portainer.io)"
+      "WebFetch(domain:docs.portainer.io)",
+      "WebFetch(domain:actualbudget.org)"
     ]
   }
 }

--- a/services/actual-server/docker-compose.yml
+++ b/services/actual-server/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  actual-server:
+    image: actualbudget/actual-server:latest-alpine
+    container_name: actual-server
+    hostname: actual-server
+    networks:
+      - traefik
+    ports:
+      - 5006:5006
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.actual-server.rule=Host(`actual-server.${USER_DOMAIN}`)
+      - traefik.http.routers.actual-server.entryPoints=websecure
+      - traefik.http.routers.actual-server.tls=true
+      - traefik.http.routers.actual-server.tls.certResolver=le
+      - traefik.http.services.actual-server.loadBalancer.server.port=5006
+    environment:
+      - TZ=America/Sao_Paulo
+    volumes:
+      - /home/pi/centerMedia/SupportApps/actual-server/data:/data
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary

- Adds `services/actual-server/docker-compose.yml` for [actualbudget/actual-server](https://actualbudget.org) — a local-first personal finance/budgeting tool
- Uses the `latest-alpine` tag (smaller Alpine-based image)
- Web UI on port **5006**, with Traefik reverse proxy labels
- Single data volume at `/home/pi/centerMedia/SupportApps/actual-server/data` (server creates `server-files` and `user-files` subdirectories automatically)

## Test plan

- [ ] Run `docker compose up -d` in `services/actual-server/`
- [ ] Verify web UI is accessible on port 5006
- [ ] Confirm Traefik routes `actual-server.${USER_DOMAIN}` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)