### PR TITLE
Add docker-compose for homarr service

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "WebFetch(domain:hub.docker.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:docs.linuxserver.io)",
-      "WebFetch(domain:docs.portainer.io)"
+      "WebFetch(domain:docs.portainer.io)",
+      "WebFetch(domain:homarr.dev)"
     ]
   }
 }

--- a/services/homarr/docker-compose.yml
+++ b/services/homarr/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  homarr:
+    image: ghcr.io/homarr-labs/homarr:latest
+    container_name: homarr
+    hostname: homarr
+    networks:
+      - traefik
+    ports:
+      - 7575:7575
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.homarr.rule=Host(`homarr.${USER_DOMAIN}`)
+      - traefik.http.routers.homarr.entryPoints=websecure
+      - traefik.http.routers.homarr.tls=true
+      - traefik.http.routers.homarr.tls.certResolver=le
+      - traefik.http.services.homarr.loadBalancer.server.port=7575
+    environment:
+      - TZ=America/Sao_Paulo
+      # Required: generate with `openssl rand -hex 32`
+      - SECRET_ENCRYPTION_KEY=${HOMARR_SECRET_ENCRYPTION_KEY}
+    volumes:
+      - /home/pi/centerMedia/SupportApps/homarr/appdata:/appdata
+      # Optional: enable Docker integration (shows container status on dashboard)
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary

- Adds `services/homarr/docker-compose.yml` for [ghcr.io/homarr-labs/homarr](https://homarr.dev) — a modern, customizable home server dashboard
- Web UI on port **7575**, with Traefik reverse proxy labels
- Includes Docker socket mount for container status integration on the dashboard

## Notes

- `SECRET_ENCRYPTION_KEY` is required — generate with `openssl rand -hex 32` and export as `HOMARR_SECRET_ENCRYPTION_KEY` in your environment or `.env` file
- Docker socket mount (`/var/run/docker.sock`) is optional but enables showing container status directly in the dashboard

## Test plan

- [ ] Generate and export `HOMARR_SECRET_ENCRYPTION_KEY`
- [ ] Run `docker compose up -d` in `services/homarr/`
- [ ] Verify web UI is accessible on port 7575
- [ ] Confirm Traefik routes `homarr.${USER_DOMAIN}` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)