### PR TITLE
Add docker-compose for obsidian service

### DIFF
--- a/services/obsidian/docker-compose.yml
+++ b/services/obsidian/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  obsidian:
+    image: lscr.io/linuxserver/obsidian:latest
+    container_name: obsidian
+    hostname: obsidian
+    networks:
+      - traefik
+    ports:
+      - 3000:3000
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.obsidian.rule=Host(`obsidian.${USER_DOMAIN}`)
+      - traefik.http.routers.obsidian.entryPoints=websecure
+      - traefik.http.routers.obsidian.tls=true
+      - traefik.http.routers.obsidian.tls.certResolver=le
+      - traefik.http.services.obsidian.loadBalancer.server.port=3000
+    environment:
+      - TZ=America/Sao_Paulo
+      - PUID=${USER_ID}
+      - PGID=${GROUP_ID}
+    volumes:
+      - /home/pi/centerMedia/SupportApps/obsidian/config:/config
+    shm_size: "1gb"
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Summary
Adds a `docker-compose.yml` for the **Obsidian** service (`lscr.io/linuxserver/obsidian:latest`), a KasmVNC-based desktop container for running Obsidian in the browser.

## Details
- Web UI on port **3000** (HTTP); Traefik terminates TLS and serves it at `obsidian.${USER_DOMAIN}`.
- Single `/config` volume mapped to `/home/pi/centerMedia/SupportApps/obsidian/config`.
- `shm_size: 1gb` added — required for the embedded browser/desktop runtime.
- Standard sqlbak ordering + watchtower auto-update labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)