### PR TITLE
Add docker-compose for siyuan

### DIFF
--- a/services/siyuan/docker-compose.yml
+++ b/services/siyuan/docker-compose.yml
@@ -17,13 +17,12 @@ services:
       - traefik.http.routers.siyuan.entryPoints=websecure
       - traefik.http.routers.siyuan.tls=true
       - traefik.http.routers.siyuan.tls.certResolver=le
-      - traefik.http.routers.siyuan.middlewares=basicAuth@docker
       - traefik.http.services.siyuan.loadBalancer.server.port=6806
     environment:
       - TZ=America/Sao_Paulo
       - PUID=${USER_ID}
       - PGID=${GROUP_ID}
-      - SIYUAN_ACCESS_AUTH_CODE=${SIYUAN_ACCESS_AUTH_CODE}
+      - SIYUAN_ACCESS_AUTH_CODE=${PASSWORD}
     volumes:
       - /home/pi/centerMedia/SupportApps/siyuan/workspace:/siyuan/workspace
     restart: unless-stopped

--- a/services/siyuan/docker-compose.yml
+++ b/services/siyuan/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  siyuan:
+    image: b3log/siyuan:latest
+    container_name: siyuan
+    hostname: siyuan
+    command: --workspace=/siyuan/workspace/
+    networks:
+      - traefik
+    ports:
+      - 6806:6806
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.siyuan.rule=Host(`siyuan.${USER_DOMAIN}`)
+      - traefik.http.routers.siyuan.entryPoints=websecure
+      - traefik.http.routers.siyuan.tls=true
+      - traefik.http.routers.siyuan.tls.certResolver=le
+      - traefik.http.routers.siyuan.middlewares=basicAuth@docker
+      - traefik.http.services.siyuan.loadBalancer.server.port=6806
+    environment:
+      - TZ=America/Sao_Paulo
+      - PUID=${USER_ID}
+      - PGID=${GROUP_ID}
+      - SIYUAN_ACCESS_AUTH_CODE=${SIYUAN_ACCESS_AUTH_CODE}
+    volumes:
+      - /home/pi/centerMedia/SupportApps/siyuan/workspace:/siyuan/workspace
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
Serviço: **siyuan** (`b3log/siyuan:latest`) — app de notas self-hosted (estilo Notion/Obsidian, blocos). Imagem multi-arch (arm64 ok).

- **UI web:** sim, porta **6806**, atrás do Traefik (`siyuan.${USER_DOMAIN}`, TLS `le`).
- **Auth:** login **nativo do SiYuan** via `SIYUAN_ACCESS_AUTH_CODE=${PASSWORD}` (env já existente no export_vars.sh). **basicAuth do Traefik removido** (serviço tem login próprio) — convenção do repo.
- **Volume:** `/home/pi/centerMedia/SupportApps/siyuan/workspace:/siyuan/workspace`.
- **Command:** `--workspace=/siyuan/workspace/`.

### Passo de deploy (no Pi4, antes do `up`)
O Docker cria a pasta sozinho, mas como `root:root` → o SiYuan roda como PUID/PGID e pode dar *permission denied*. Criar com o dono certo antes:
```bash
mkdir -p /home/pi/centerMedia/SupportApps/siyuan/workspace
sudo chown -R "$USER_ID:$GROUP_ID" /home/pi/centerMedia/SupportApps/siyuan
```
(LinuxServer images fazem isso sozinhas; o SiYuan não.)

Gerado pela skill docker-compose-create.