### PR TITLE
Add docker-compose for mealie

### DIFF
--- a/services/mealie/docker-compose.yml
+++ b/services/mealie/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  mealie:
+    image: ghcr.io/mealie-recipes/mealie:latest
+    container_name: mealie
+    hostname: mealie
+    networks:
+      - traefik
+    ports:
+      - 9925:9000
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.mealie.rule=Host(`mealie.${USER_DOMAIN}`)
+      - traefik.http.routers.mealie.entryPoints=websecure
+      - traefik.http.routers.mealie.tls=true
+      - traefik.http.routers.mealie.tls.certResolver=le
+      - traefik.http.services.mealie.loadBalancer.server.port=9000
+    environment:
+      - TZ=America/Sao_Paulo
+      - PUID=${USER_ID}
+      - PGID=${GROUP_ID}
+      - ALLOW_SIGNUP=false
+      - BASE_URL=https://mealie.${USER_DOMAIN}
+      - MAX_WORKERS=1
+      - WEB_CONCURRENCY=1
+    volumes:
+      - /home/pi/centerMedia/SupportApps/mealie/data:/app/data
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
Serviço: **mealie** (gerenciador de receitas self-hosted) — imagem `ghcr.io/mealie-recipes/mealie:latest` (multi-arch, arm64 ✅).

**UI web:** sim · porta host **9925** → container 9000 (9925 estava livre).
**Auth:** Mealie tem **login nativo** → removi o `basicAuth@docker` (conforme convenção). Admin padrão no 1º acesso: `changeme@example.com` / `MyPassword` — **trocar logo após entrar**. `ALLOW_SIGNUP=false` pra ninguém se cadastrar sozinho.
**Volume:** `/home/pi/centerMedia/SupportApps/mealie/data:/app/data` (SQLite + imagens das receitas).
**Env:** TZ, PUID/PGID, `BASE_URL=https://mealie.${USER_DOMAIN}` (necessário pro frontend atrás do Traefik), `MAX_WORKERS=1` + `WEB_CONCURRENCY=1` (recomendado pela doc pra reduzir memória no Pi).

**Passo manual no Pi4 antes do `up`** (a imagem não é LinuxServer e pode não dar chown sozinha):
```
mkdir -p /home/pi/centerMedia/SupportApps/mealie/data && sudo chown -R "$USER_ID:$GROUP_ID" /home/pi/centerMedia/SupportApps/mealie
```

**Nota:** está em `:latest` + watchtower (padrão do repo). Como o Mealie roda migrations de DB em upgrade, se quiser evitar surpresa dá pra pinar a versão (ex.: `:v3.20.1`) — só avisar que eu ajusto.

Gerado pela skill docker-compose-create.