### PR TITLE
Add docker-compose for lazydocker (TUI, arm64 build)

### DIFF
--- a/services/lazydocker/docker-compose.yml
+++ b/services/lazydocker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: https://github.com/jesseduffield/lazydocker.git
       args:
-        BASE_IMAGE_BUILDER: golang
+        BASE_IMAGE_BUILDER: arm64v8/golang
         GOARCH: arm64
         GOARM: ""
     image: lazydocker:local

--- a/services/lazydocker/docker-compose.yml
+++ b/services/lazydocker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     stdin_open: true
     tty: true
     build:
-      context: https://github.com/jesseduffield/lazydocker.git
+      context: https://github.com/jesseduffield/lazydocker.git#v0.25.2
       args:
         BASE_IMAGE_BUILDER: arm64v8/golang
         GOARCH: arm64

--- a/services/lazydocker/docker-compose.yml
+++ b/services/lazydocker/docker-compose.yml
@@ -1,24 +1,23 @@
 services:
   lazydocker:
-    # Imagem oficial (lazyteam/lazydocker) é somente amd64 -> no arm64 do Pi
-    # precisamos buildar do fonte cruzando pra arm64.
-    build:
-      context: https://github.com/jesseduffield/lazydocker.git
-      args:
-        BASE_IMAGE_BUILDER: arm64v8/golang
-        GOARCH: arm64
-        GOARM: ""
     image: lazydocker:local
     container_name: lazydocker
     hostname: lazydocker
-    # TUI de terminal: precisa de stdin + tty. Sem web, sem porta, sem Traefik.
-    stdin_open: true
-    tty: true
-    # watchtower NÃO habilitado de propósito: a imagem é buildada localmente;
-    # um pull automático traria a versão amd64 e quebraria o container.
     environment:
       - TZ=America/Sao_Paulo
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /home/pi/centerMedia/SupportApps/lazydocker:/.config/jesseduffield/lazydocker
     restart: unless-stopped
+    # Itens específicos do lazydocker (não existem nos outros composes):
+    # - TUI de terminal: precisa de stdin + tty (sem web, sem porta/Traefik).
+    # - Imagem oficial lazyteam/lazydocker é só amd64 -> build do fonte cruzando pra arm64.
+    # - watchtower fica desabilitado de propósito (build local; pull traria amd64).
+    stdin_open: true
+    tty: true
+    build:
+      context: https://github.com/jesseduffield/lazydocker.git
+      args:
+        BASE_IMAGE_BUILDER: arm64v8/golang
+        GOARCH: arm64
+        GOARM: ""

--- a/services/lazydocker/docker-compose.yml
+++ b/services/lazydocker/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  lazydocker:
+    # Imagem oficial (lazyteam/lazydocker) é somente amd64 -> no arm64 do Pi
+    # precisamos buildar do fonte cruzando pra arm64.
+    build:
+      context: https://github.com/jesseduffield/lazydocker.git
+      args:
+        BASE_IMAGE_BUILDER: golang
+        GOARCH: arm64
+        GOARM: ""
+    image: lazydocker:local
+    container_name: lazydocker
+    hostname: lazydocker
+    # TUI de terminal: precisa de stdin + tty. Sem web, sem porta, sem Traefik.
+    stdin_open: true
+    tty: true
+    # watchtower NÃO habilitado de propósito: a imagem é buildada localmente;
+    # um pull automático traria a versão amd64 e quebraria o container.
+    environment:
+      - TZ=America/Sao_Paulo
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /home/pi/centerMedia/SupportApps/lazydocker:/.config/jesseduffield/lazydocker
+    restart: unless-stopped

--- a/services/lazydocker/docker-compose.yml
+++ b/services/lazydocker/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     image: lazydocker:local
     container_name: lazydocker
     hostname: lazydocker
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      # watchtower desabilitado de propósito: imagem buildada localmente;
+      # um pull automático traria a versão amd64 e quebraria o container.
+      - com.centurylinklabs.watchtower.enable=false
     environment:
       - TZ=America/Sao_Paulo
     volumes:
@@ -12,7 +18,6 @@ services:
     # Itens específicos do lazydocker (não existem nos outros composes):
     # - TUI de terminal: precisa de stdin + tty (sem web, sem porta/Traefik).
     # - Imagem oficial lazyteam/lazydocker é só amd64 -> build do fonte cruzando pra arm64.
-    # - watchtower fica desabilitado de propósito (build local; pull traria amd64).
     stdin_open: true
     tty: true
     build:


### PR DESCRIPTION
Serviço: **lazydocker** (gerenciador de Docker via **terminal/TUI** — não tem web UI).

⚠️ **Caso atípico** — foge do padrão da stack de propósito:
- **Sem web** → sem `ports`, sem Traefik, sem network `traefik`.
- **É uma TUI interativa** → `stdin_open: true` + `tty: true`. Você usa ela anexando no container, não pelo navegador.
- **Arquitetura:** a imagem oficial `lazyteam/lazydocker` é **só amd64** (confirmei no Docker Hub) → **não roda no arm64** do Pi4. Por isso o compose **builda do fonte** (repo deles) com `GOARCH: arm64`. O 1º `up --build` compila (leva alguns minutos no Pi).
- Tag local **`lazydocker:local`** (em vez de `lazyteam/lazydocker`) pra não confundir com a imagem amd64 do Hub.
- **watchtower NÃO habilitado** de propósito: como é build local, um pull automático puxaria a versão amd64 e quebraria o container.

**Volumes:**
- `/var/run/docker.sock` (pra enxergar/gerenciar os containers)
- `/home/pi/centerMedia/SupportApps/lazydocker` → config do lazydocker (padrão do repo)

**Como usar** (depois do merge + `pull` no Pi4):
```
docker compose -f services/lazydocker/docker-compose.yml up -d --build   # 1ª vez compila
docker attach lazydocker      # abre a TUI  (destaca com Ctrl-P Ctrl-Q)
```
Alternativa sem deixar rodando: `docker compose run --rm lazydocker`.

Gerado pela skill docker-compose-create (adaptado pro caso TUI/arm64).