### PR TITLE
Add docker-compose for keepassxc

### DIFF
--- a/services/keepassxc/docker-compose.yml
+++ b/services/keepassxc/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  keepassxc:
+    image: lscr.io/linuxserver/keepassxc:latest
+    container_name: keepassxc
+    hostname: keepassxc
+    networks:
+      - traefik
+    ports:
+      - 3011:3001
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.keepassxc.rule=Host(`keepassxc.${USER_DOMAIN}`)
+      - traefik.http.routers.keepassxc.entryPoints=websecure
+      - traefik.http.routers.keepassxc.tls=true
+      - traefik.http.routers.keepassxc.tls.certResolver=le
+      - traefik.http.services.keepassxc.loadBalancer.server.port=3000
+    environment:
+      - TZ=America/Sao_Paulo
+      - PUID=${USER_ID}
+      - PGID=${GROUP_ID}
+      # Auth nativa da imagem (HTTP basic) — sem basicAuth do Traefik, conforme convenção
+      - CUSTOM_USER=rodrigo
+      - PASSWORD=${PASSWORD}
+      # Hardening: desliga terminal/sudo/open-tools do desktop (só precisamos do KeePassXC)
+      - HARDEN_DESKTOP=true
+    volumes:
+      - /home/pi/centerMedia/SupportApps/keepassxc/config:/config
+    restart: unless-stopped
+    # Recomendado pra imagens de desktop (LinuxServer)
+    shm_size: "1gb"
+
+networks:
+  traefik:
+    external: true
+    name: traefik

--- a/services/keepassxc/docker-compose.yml
+++ b/services/keepassxc/docker-compose.yml
@@ -21,8 +21,8 @@ services:
       - TZ=America/Sao_Paulo
       - PUID=${USER_ID}
       - PGID=${GROUP_ID}
-      # Auth nativa da imagem (HTTP basic) — sem basicAuth do Traefik, conforme convenção
-      - CUSTOM_USER=rodrigo
+      # Auth nativa da imagem (HTTP basic)
+      - CUSTOM_USER=${USERNAME}
       - PASSWORD=${PASSWORD}
       # Hardening: desliga terminal/sudo/open-tools do desktop (só precisamos do KeePassXC)
       - HARDEN_DESKTOP=true


### PR DESCRIPTION
Serviço: **keepassxc** (gerenciador de senhas) — imagem **LinuxServer** `lscr.io/linuxserver/keepassxc:latest` (multi-arch, arm64 ✅). É um **desktop GUI servido no navegador** (stack Selkies).

**UI web:** sim, via Traefik em `keepassxc.${USER_DOMAIN}`.
- A imagem serve **3000 (http)** e **3001 (https, cert self-signed)**.
- O Traefik roteia pro **3000** (http interno) e entrega **HTTPS** pro navegador (cert Let's Encrypt). Assim o browser fica em contexto seguro (necessário pra clipboard/WebCodecs) sem a treta do cert self-signed no backend.
- Porta **3000 do host já estava ocupada** → exponho **`3011:3001`** pra acesso direto https opcional (https://<pi4>:3011, self-signed).

**Auth:** a imagem **não tem auth por padrão**, mas suporta **basic auth nativa** (`CUSTOM_USER`/`PASSWORD`). Segui a convenção: **removi o basicAuth do Traefik** e usei `PASSWORD=${PASSWORD}` + `CUSTOM_USER=rodrigo`.

**🔐 Segurança (importante):** a doc avisa que o GUI dá **terminal com sudo root** dentro do container. Como você só precisa do app KeePassXC, adicionei **`HARDEN_DESKTOP=true`** (desliga terminal/sudo/open-tools) pra reduzir a superfície de ataque. **Recomendo NÃO expor isso na internet** — só rede local/VPN.

**Volume:** `/home/pi/centerMedia/SupportApps/keepassxc/config:/config` (home do usuário no container — salve seu `.kdbx` aqui pra persistir). Imagem LinuxServer dá chown sozinha (PUID/PGID) → sem passo manual de permissão.

**`shm_size: 1gb`** — recomendado pra imagens de desktop.

**Env nova no `export_vars.sh`:** usa `${PASSWORD}` (já existe) e `${USER_DOMAIN}`/`${USER_ID}`/`${GROUP_ID}` (já existem). Nada novo a adicionar.

**Se não subir** (kernel/seccomp): a doc menciona que apps de desktop podem precisar de `security_opt: ["seccomp=unconfined"]` em kernels/libseccomp antigos. O Pi4 tem kernel moderno, então deixei **sem** — se der erro de syscall, me avisa que eu adiciono.

Gerado pela skill docker-compose-create.