### PR TITLE
Add docker-compose for vaultwarden

### DIFF
--- a/services/vaultwarden/docker-compose.yml
+++ b/services/vaultwarden/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  vaultwarden:
+    image: vaultwarden/server:latest
+    container_name: vaultwarden
+    hostname: vaultwarden
+    networks:
+      - traefik
+    ports:
+      - 8222:80
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=true
+      - traefik.http.routers.vaultwarden.rule=Host(`vaultwarden.${USER_DOMAIN}`)
+      - traefik.http.routers.vaultwarden.entryPoints=websecure
+      - traefik.http.routers.vaultwarden.tls=true
+      - traefik.http.routers.vaultwarden.tls.certResolver=le
+      - traefik.http.services.vaultwarden.loadBalancer.server.port=80
+    environment:
+      - TZ=America/Sao_Paulo
+      # Obrigatório: usado por 2FA/WebAuthn, anexos e links. Precisa bater com a URL real.
+      - DOMAIN=https://vaultwarden.${USER_DOMAIN}
+      # Cadastro público desligado. Crie seu usuário via painel /admin (ADMIN_TOKEN).
+      - SIGNUPS_ALLOWED=false
+      - ADMIN_TOKEN=${PASSWORD}
+    volumes:
+      - /home/pi/centerMedia/SupportApps/vaultwarden/data:/data
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
Serviço: **vaultwarden** (servidor compatível com Bitwarden, em Rust) — imagem `vaultwarden/server:latest` (multi-arch, **arm64 ✅**).

**UI web:** sim. Container escuta na **porta 80**; exponho **`8222:80`** no host (8222 estava livre). Traefik roteia `vaultwarden.${USER_DOMAIN}` → porta 80 interna.

**Auth:** vaultwarden **tem contas/login nativos** → conforme a convenção, **sem `basicAuth@docker`**.
> ⚠️ Isso aqui é **obrigatório**, não só convenção: os clientes Bitwarden (app celular, extensão de browser) **não conseguem** passar por HTTP basic auth. Com basicAuth o app não sincroniza.

**Env:**
- `DOMAIN=https://vaultwarden.${USER_DOMAIN}` — **obrigatório**; usado por 2FA/WebAuthn, anexos e links de convite. Tem que bater com a URL real.
- `SIGNUPS_ALLOWED=false` — cadastro público **desligado desde o minuto zero** (não deixa janela aberta na internet).
- `ADMIN_TOKEN=${PASSWORD}` — habilita o painel `/admin`. **É por lá que você cria/convida o seu usuário** (já que o signup está off).

**Volume:** `/home/pi/centerMedia/SupportApps/vaultwarden/data:/data` (SQLite + anexos + config).

**Sobre PUID/PGID:** vaultwarden **não suporta** essas vars (não é LinuxServer) — o container roda como root e escreve no `/data`. Por isso **não incluí** (seriam decorativas). Sem passo manual de chown.

## Passos após o merge (no Pi4)
1. `git pull` + `docker compose -f services/vaultwarden/docker-compose.yml up -d`
2. Acessa `https://vaultwarden.${USER_DOMAIN}/admin`, entra com o **ADMIN_TOKEN** (= `${PASSWORD}`) e **convida seu e-mail** pra criar a conta.

## Recomendação de hardening (opcional)
O vaultwarden recomenda que o `ADMIN_TOKEN` seja um **hash Argon2** em vez de texto puro (ele loga um aviso). Pra gerar:
```
docker exec -it vaultwarden /vaultwarden hash
```
e trocar o valor. Se preferir, dá pra **omitir o ADMIN_TOKEN** de vez depois de criar sua conta — isso desativa o painel /admin (mais seguro).

Gerado pela skill docker-compose-create.