### PR TITLE
Add docker-compose for watchyourlan

### DIFF
--- a/services/watchyourlan/docker-compose.yml
+++ b/services/watchyourlan/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  watchyourlan:
+    image: aceberg/watchyourlan:latest
+    container_name: watchyourlan
+    hostname: watchyourlan
+    environment:
+      - TZ=America/Sao_Paulo
+      # Interface da LAN a ser escaneada (Pi4 = eth0, confirmado via ip addr)
+      - IFACES=eth0
+      - HOST=0.0.0.0
+      - PORT=8840
+    volumes:
+      - /home/pi/centerMedia/SupportApps/watchyourlan/data:/data/WatchYourLAN
+    restart: unless-stopped
+    # Itens específicos do watchyourlan (não existem nos outros composes):
+    # - network_mode: host é OBRIGATÓRIO — o arp-scan precisa enxergar a LAN direto.
+    #   Como o Docker não permite host + networks juntos, este serviço NÃO entra na
+    #   rede traefik e NÃO tem labels/roteamento do Traefik.
+    # - Consequência: a UI fica exposta direto no host em http://<pi4>:8840 (sem TLS,
+    #   sem basicAuth). O próprio README do projeto alerta pra restringir por firewall.
+    # - Sem PUID/PGID: a imagem não usa essas vars (não é LinuxServer).
+    network_mode: host


### PR DESCRIPTION
Serviço: **watchyourlan** (scanner de rede local — lista hosts, avisa quando aparece host novo) — imagem `aceberg/watchyourlan:latest` (multi-arch, **arm64 ✅**).

⚠️ **Caso atípico — foge do padrão da stack por necessidade técnica:**

**`network_mode: host` é OBRIGATÓRIO.** O WYL usa `arp-scan` pra varrer a LAN, e isso só funciona se o container enxergar a rede do host direto. O README do projeto é explícito: *"Network mode must be host"*.

**Consequências (e é importante você saber):**
- O Docker **não permite** `network_mode: host` + `networks:` juntos → este serviço **não entra na rede traefik** e **não tem labels do Traefik**.
- Sem Traefik = **sem TLS e sem basicAuth**. A UI fica exposta direto em **`http://<pi4>:8840`**.
- O próprio README alerta: *"WYL port will be exposed in this setup. You need to limit access to it with firewall or other measures."*
- Também não uso `ports:` (host mode não aceita mapeamento — a porta 8840 já sai direto no host).

**Env:**
- `IFACES=eth0` — **confirmei por SSH no Pi4** que a interface da LAN é `eth0` (192.168.10.100/24). É essa que o WYL vai escanear.
- `TZ`, `HOST=0.0.0.0`, `PORT=8840`.
- **Sem PUID/PGID** — a imagem não usa essas vars (não é LinuxServer), seriam decorativas.

**Volume:** `/home/pi/centerMedia/SupportApps/watchyourlan/data:/data/WatchYourLAN` (banco de hosts + config).

**Passo manual no Pi4 antes do `up`** (imagem não-LinuxServer, pode não dar chown sozinha):
```
mkdir -p /home/pi/centerMedia/SupportApps/watchyourlan/data && sudo chown -R "$USER_ID:$GROUP_ID" /home/pi/centerMedia/SupportApps/watchyourlan
```

**Acesso depois de subir:** `http://192.168.10.100:8840`

**Recomendação de segurança:** como não dá pra pôr atrás do Traefik, mantenha **só na LAN** (não faça port-forward no roteador). Se quiser HTTPS/auth mesmo assim, dá pra configurar uma rota estática no Traefik apontando pra `http://192.168.10.100:8840` — mas isso é config do Traefik, fora deste compose. Me avisa se quiser que eu monte.

Gerado pela skill docker-compose-create (adaptado pro caso host-network).