### PR TITLE
Add docker-compose for mongo + rabbitmq (LAN-only)

### DIFF
--- a/services/mongo/docker-compose.yml
+++ b/services/mongo/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  mongo:
+    image: mongo:8.0.28-noble
+    container_name: mongo
+    hostname: mongo
+    networks:
+      - traefik
+    ports:
+      # LAN-only: acessível na rede local (host:container). SEM Traefik = não vai pro mundo.
+      - 27017:27017
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      # watchtower OFF: versão pinada de propósito (8.0.28-noble). Update é manual.
+      - com.centurylinklabs.watchtower.enable=false
+    environment:
+      - TZ=America/Sao_Paulo
+      # Credenciais root — só aplicadas no PRIMEIRO boot (data dir vazio).
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ROOT_PASSWORD}
+    volumes:
+      - /home/pi/centerMedia/SupportApps/mongo/data:/data/db
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik

--- a/services/mongo/docker-compose.yml
+++ b/services/mongo/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - TZ=America/Sao_Paulo
       # Credenciais root — só aplicadas no PRIMEIRO boot (data dir vazio).
       - MONGO_INITDB_ROOT_USERNAME=admin
-      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ROOT_PASSWORD}
+      - MONGO_INITDB_ROOT_PASSWORD=${PASSWORD}
     volumes:
       - /home/pi/centerMedia/SupportApps/mongo/data:/data/db
     restart: unless-stopped

--- a/services/rabbitmq/docker-compose.yml
+++ b/services/rabbitmq/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - TZ=America/Sao_Paulo
       # Login (AMQP + management UI) — só aplicado no PRIMEIRO boot (data dir vazio).
       - RABBITMQ_DEFAULT_USER=admin
-      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
+      - RABBITMQ_DEFAULT_PASS=${PASSWORD}
     volumes:
       - /home/pi/centerMedia/SupportApps/rabbitmq/data:/var/lib/rabbitmq
     restart: unless-stopped

--- a/services/rabbitmq/docker-compose.yml
+++ b/services/rabbitmq/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  rabbitmq:
+    image: rabbitmq:4.2.7-management-alpine
+    container_name: rabbitmq
+    # hostname FIXO é importante: o RabbitMQ nomeia o node como rabbit@<hostname>.
+    # Se o hostname mudar, ele "perde" os dados (vira outro node).
+    hostname: rabbitmq
+    networks:
+      - traefik
+    ports:
+      # LAN-only (sem Traefik). AMQP + UI de management.
+      - 5672:5672
+      - 15672:15672
+    labels:
+      - sqlbak.stop.first=true
+      - sqlbak.start.first=false
+      # watchtower OFF: versão pinada (4.2.7-management-alpine). Update é manual.
+      - com.centurylinklabs.watchtower.enable=false
+    environment:
+      - TZ=America/Sao_Paulo
+      # Login (AMQP + management UI) — só aplicado no PRIMEIRO boot (data dir vazio).
+      - RABBITMQ_DEFAULT_USER=admin
+      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
+    volumes:
+      - /home/pi/centerMedia/SupportApps/rabbitmq/data:/var/lib/rabbitmq
+    restart: unless-stopped
+
+networks:
+  traefik:
+    external: true
+    name: traefik

--- a/services/rabbitmq/docker-compose.yml
+++ b/services/rabbitmq/docker-compose.yml
@@ -8,9 +8,15 @@ services:
     networks:
       - traefik
     ports:
-      # LAN-only (sem Traefik). AMQP + UI de management.
-      - 5672:5672
-      - 15672:15672
+      # LAN-only (sem Traefik).
+      - 5672:5672       # AMQP
+      - 5671:5671       # AMQP over TLS
+      - 15672:15672     # Management UI (HTTP)
+      - 15671:15671     # Management UI over TLS
+      - 15692:15692     # Prometheus metrics
+      - 15691:15691     # Prometheus metrics over TLS
+      - 25672:25672     # Erlang distribution (inter-node / rabbitmqctl remoto)
+      - 4369:4369       # epmd (Erlang port mapper)
     labels:
       - sqlbak.stop.first=true
       - sqlbak.start.first=false


### PR DESCRIPTION
Dois serviços de infra, **LAN-only** (sem Traefik, sem exposição pública), nas versões que você pediu.

## 🍃 mongo — `mongo:8.0.28-noble` (arm64 ✅)
- **Porta:** `27017:27017` (acesso na LAN via `192.168.10.100:27017`)
- **Auth nativa:** `admin` / `${MONGO_ROOT_PASSWORD}`
- **Volume:** `SupportApps/mongo/data:/data/db`
- Sem chown manual: o entrypoint do Mongo dá `chown` no `/data/db` sozinho.

## 🐰 rabbitmq — `rabbitmq:4.2.7-management-alpine` (arm64 ✅)
- **Portas:** `5672` (AMQP) + `15672` (UI de management)
- **Login (AMQP + UI):** `admin` / `${RABBITMQ_DEFAULT_PASS}`
- **Volume:** `SupportApps/rabbitmq/data:/var/lib/rabbitmq`
- `hostname: rabbitmq` fixo — o RabbitMQ nomeia o node como `rabbit@<hostname>`; se o hostname variar, ele perde os dados. Fixar garante persistência.

## Decisões (iguais nas duas)
- **Sem Traefik / sem `traefik.enable`** → não roteia pra internet. As portas ficam só no host → **na LAN**. Ficam na rede `traefik` só pra outros containers alcançarem por nome (`mongo`, `rabbitmq`) — isso NÃO expõe pra fora.
- **watchtower OFF** — versões **pinadas** de propósito (você pediu exatas). Update é manual.
- **Sem PUID/PGID** — imagens oficiais não usam (Mongo roda como uid 999, Rabbit idem).

## ⚠️ Passos manuais antes de subir (no Pi4)
1. **Adicionar 2 segredos no `export_vars.sh`** (não podem ir hardcoded no repo público):
   ```
   MONGO_ROOT_PASSWORD=<senha forte>
   RABBITMQ_DEFAULT_PASS=<senha forte>
   ```
   (gera com `openssl rand -base64 24`), depois recarrega o env.
2. Criar as pastas de dados:
   ```
   mkdir -p /home/pi/centerMedia/SupportApps/{mongo,rabbitmq}/data
   ```

## 🔒 Gotcha importante (Mongo e Rabbit)
As credenciais (`MONGO_INITDB_ROOT_*` / `RABBITMQ_DEFAULT_*`) **só são aplicadas no PRIMEIRO boot**, com o data dir vazio. Se você subir sem a env setada e depois setar, **não pega** — tem que apagar o data dir e subir de novo. Então: **setar os segredos ANTES do primeiro `up`.**

## Segurança
Mesmo LAN-only, deixei auth ligada (qualquer device na tua rede alcançaria senão). **Não faça port-forward** de 27017/5672/15672 no roteador — Mongo/Rabbit expostos na internet são alvo clássico de ransomware/bots.

Gerado seguindo o padrão do repo (adaptado pro caso infra/LAN-only).