### PR TITLE
Add docker-compose for lan-orangutan

### DIFF
--- a/services/lan-orangutan/docker-compose.yml
+++ b/services/lan-orangutan/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  lan-orangutan:
+    image: ghcr.io/291-group/lan-orangutan:latest
+    container_name: lan-orangutan
+    hostname: lan-orangutan
+    environment:
+      - TZ=America/Sao_Paulo
+      - ORANGUTAN_PORT=291
+      # Auth nativa do app (pede senha na 1ª abertura da UI). Convenção do Rodrigo
+      # p/ serviços com login próprio: usar ${PASSWORD}. Se preferir criar a senha
+      # manualmente na primeira abertura, comente a linha abaixo.
+      - ORANGUTAN_PASSWORD=${PASSWORD}
+    volumes:
+      # A imagem fixa ORANGUTAN_DATA_DIR=/var/lib/lan-orangutan; persistir aqui.
+      - /home/pi/centerMedia/SupportApps/lan-orangutan/data:/var/lib/lan-orangutan
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
+      - NET_BIND_SERVICE
+    restart: unless-stopped
+    # Itens específicos do lan-orangutan (mesmo padrão do watchyourlan):
+    # - network_mode: host é OBRIGATÓRIO — o nmap precisa enxergar a LAN direto;
+    #   em bridge só veria outros containers (172.17.0.0/16). Como o Docker não
+    #   permite host + networks juntos, este serviço NÃO entra na rede traefik e
+    #   NÃO tem labels/roteamento do Traefik.
+    # - Consequência: a UI fica exposta direto no host em http://<pi4>:291
+    #   (a auth nativa do app protege; sem TLS/basicAuth do Traefik). Restringir
+    #   por firewall se necessário.
+    # - Roda como root (default da imagem) + caps: NET_RAW/NET_ADMIN pro nmap ler a
+    #   tabela ARP (MAC + fabricante) e NET_BIND_SERVICE pra porta privilegiada 291.
+    # - Sem PUID/PGID: a imagem não usa essas vars (não é LinuxServer; roda root).
+    network_mode: host


### PR DESCRIPTION
## Serviço: lan-orangutan
Scanner de rede self-hosted (Go + nmap) com labeling persistente de devices, multi-rede e integração Tailscale. Imagem oficial `ghcr.io/291-group/lan-orangutan:latest` (multi-arch, **arm64 ok** → roda nativo no Pi).

## UI web
Sim, porta **291**. Acesso **direto** em `http://<pi4>:291` — **sem Traefik** (ver abaixo).

## ⚠️ Host networking (igual watchyourlan / PR #30)
- `network_mode: host` é **obrigatório**: o nmap precisa enxergar a LAN real; em bridge só veria outros containers.
- Como Docker não permite `host` + `networks` juntos, o serviço **não entra na rede traefik** e **não tem labels/roteamento do Traefik**. A UI fica exposta direto no host (restringir por firewall se necessário).
- Roda como **root** (default da imagem) + caps `NET_RAW`/`NET_ADMIN` (nmap lê a tabela ARP → MAC + fabricante) e `NET_BIND_SERVICE` (porta privilegiada 291).
- Sem `PUID/PGID` (imagem não é LinuxServer).

## Volumes
- `/home/pi/centerMedia/SupportApps/lan-orangutan/data:/var/lib/lan-orangutan` (device list, labels e senha). A imagem fixa `ORANGUTAN_DATA_DIR=/var/lib/lan-orangutan`.

## Env
- `TZ`, `ORANGUTAN_PORT=291`, `ORANGUTAN_PASSWORD=${PASSWORD}` (auth nativa; usa a var que já existe no `export_vars.sh`). Se preferir criar a senha na 1ª abertura da UI, comentar essa linha.

## Passos manuais
Nenhum obrigatório (container roda root → escreve no volume sem chown). O dir do host é criado no 1º `up`.

## 💡 Observação
Sobrepõe o **watchyourlan** (PR #30) — ambos são scanners de LAN. O Orangutan tem labeling/notas persistentes, multi-rede, Tailscale e UI mais completa. Talvez valha escolher **um** dos dois pra não varrer a rede em paralelo.

Gerado pela skill docker-compose-create.