### PR TITLE
Add docker-compose for cloudflared (Cloudflare Tunnel)

### DIFF
--- a/services/cloudflared/docker-compose.yml
+++ b/services/cloudflared/docker-compose.yml
@@ -24,7 +24,8 @@ services:
     # - Fica na rede `traefik` pra alcançar os outros serviços por nome de container
     #   (ex.: destino http://n8n:5678) ou via IP do host (http://192.168.10.100:<porta>).
     # - Sem PUID/PGID: a imagem cloudflared não usa (não é LinuxServer).
-    # - Multi-arch (arm64 ok no Pi).
+    # - Arch: a imagem oficial só publica amd64/arm64 (NÃO tem arm/v7 32-bit).
+    #   Requer Pi 64-bit (arm64). Confirmado no Pi4 = aarch64/arm64 → pull OK.
 
 networks:
   traefik:

--- a/services/cloudflared/docker-compose.yml
+++ b/services/cloudflared/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: cloudflared
+    hostname: cloudflared
+    networks:
+      - traefik
+    command: tunnel --no-autoupdate run
+    labels:
+      - sqlbak.stop.first=false
+      - sqlbak.start.first=true
+      - com.centurylinklabs.watchtower.enable=true
+    environment:
+      - TZ=America/Sao_Paulo
+      # Token do túnel (Cloudflare Zero Trust → Networks → Tunnels → teu túnel).
+      # Adicionar CLOUDFLARE_TUNNEL_TOKEN no export_vars.sh (segredo, não commitar).
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    restart: unless-stopped
+    # cloudflared é o conector do Cloudflare Tunnel (saída → nuvem), imune a CGNAT.
+    # - SEM ports / SEM labels traefik: não recebe conexão de entrada; ele DISCA
+    #   pra Cloudflare. As rotas (public hostnames) são configuradas no painel do
+    #   Cloudflare (túnel "remote-managed" por token), não aqui no compose.
+    # - Fica na rede `traefik` pra alcançar os outros serviços por nome de container
+    #   (ex.: destino http://n8n:5678) ou via IP do host (http://192.168.10.100:<porta>).
+    # - Sem PUID/PGID: a imagem cloudflared não usa (não é LinuxServer).
+    # - Multi-arch (arm64 ok no Pi).
+
+networks:
+  traefik:
+    external: true
+    name: traefik

--- a/services/cloudflared/docker-compose.yml
+++ b/services/cloudflared/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     environment:
       - TZ=America/Sao_Paulo
       # Token do túnel (Cloudflare Zero Trust → Networks → Tunnels → teu túnel).
-      # Adicionar CLOUDFLARE_TUNNEL_TOKEN no export_vars.sh (segredo, não commitar).
+      # Definir CLOUDFLARE_TUNNEL_TOKEN em /etc/environment no Pi4 (export_vars.sh
+      # está deprecado). Segredo — não commitar.
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
     restart: unless-stopped
     # cloudflared é o conector do Cloudflare Tunnel (saída → nuvem), imune a CGNAT.


### PR DESCRIPTION
## Serviço: cloudflared (Cloudflare Tunnel)
Conector do **Cloudflare Tunnel** — resolve o acesso externo que quebrou com o **CGNAT da Claro** (WAN do mesh = 100.72.180.247, faixa 100.64/10 → port-forward impossível). O cloudflared **disca de dentro pra fora**, então dispensa port-forward, IP público e DNS dinâmico.

## Como funciona
- **Sem ports / sem labels Traefik:** não recebe conexão de entrada; conecta na nuvem Cloudflare.
- Túnel **remote-managed (por token)**: as *public hostnames* (ex.: `n8n.rodrigoma.com.br`) são configuradas no **painel** Cloudflare Zero Trust, não no compose. O DNS (CNAME) é criado automático pela Cloudflare.
- Fica na rede `traefik` pra alcançar os serviços por nome de container ou via IP do host.

## ⚠️ Passo manual (obrigatório)
Adicionar o token no **export_vars.sh** do Pi4 (segredo — NÃO commitar):
```
export CLOUDFLARE_TUNNEL_TOKEN=eyJ...   # copiar do painel Cloudflare (Docker tab do túnel)
```

## Domínio
`rodrigoma.com.br` já ativo no Cloudflare (nameservers migrados do GoDaddy). Sem MX → e-mail não afetado.

## Pós-merge (deploy no Pi4)
1. Criar o túnel em Zero Trust → Networks → Tunnels (conector Cloudflared, tipo Docker) → copiar token → pôr no export_vars.sh.
2. Adicionar public hostname `n8n.rodrigoma.com.br` → Service `http://n8n:5678` (ou IP:porta do n8n).
3. `docker compose up -d` do cloudflared. Sem chown/volume.

Gerado pela skill docker-compose-create.