### PR TITLE
traefik: ACME DNS-challenge duckdns → cloudflare

### DIFF
--- a/services/traefik/docker-compose.yml
+++ b/services/traefik/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - --entryPoints.websecure.address=:443
       - --entryPoints.websecure.http.tls=true
       - --certificatesresolvers.le.acme.dnsChallenge=true
-      - --certificatesresolvers.le.acme.dnsChallenge.provider=duckdns
+      - --certificatesresolvers.le.acme.dnsChallenge.provider=cloudflare
       - --certificatesresolvers.le.acme.dnsChallenge.propagation.delayBeforeChecks=60s
       - --certificatesresolvers.le.acme.email=${USER_EMAIL}
       - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
@@ -44,7 +44,10 @@ services:
       - traefik.http.services.api.loadBalancer.server.port=8080
     environment:
       - TZ=America/Sao_Paulo
-      - DUCKDNS_TOKEN=${DUCKDNS_TOKEN}
+      # ACME DNS-challenge agora via Cloudflare (substitui o DuckDNS).
+      # Token scoped em /etc/environment: precisa de Zone:DNS:Edit + Zone:Zone:Read
+      # para a zona rodrigoma.com.br. (lego provider "cloudflare")
+      - CF_DNS_API_TOKEN=${CF_DNS_API_TOKEN}
     volumes:
       - /home/pi/centerMedia/SupportApps/letsencrypt:/letsencrypt
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
## O que muda
Troca o provider do desafio ACME (Let's Encrypt) de **duckdns** para **cloudflare**, agora que `rodrigoma.com.br` está no Cloudflare. Elimina a dependência do DuckDNS.

- `--certificatesresolvers.le.acme.dnsChallenge.provider=duckdns` → `cloudflare`
- env: `DUCKDNS_TOKEN` → `CF_DNS_API_TOKEN`

## ⚠️ Pré-requisitos (Pi4, /etc/environment — export_vars.sh está deprecado)
- `CF_DNS_API_TOKEN` = **API token do Cloudflare** com **Zone:DNS:Edit + Zone:Zone:Read** na zona `rodrigoma.com.br`. (É um token DIFERENTE do token do túnel!)
- `USER_DOMAIN=rodrigoma.com.br` (trocar de rodrigoma.duckdns.org).

## ⚠️ Coordenar o deploy (fazer junto, mesma janela)
Esta PR + a troca do `USER_DOMAIN` para rodrigoma.com.br têm que subir **juntas**: com o provider cloudflare mas o domínio ainda duckdns, o ACME falharia. Ordem sugerida:
1. Ajustar /etc/environment (USER_DOMAIN=rodrigoma.com.br, CF_DNS_API_TOKEN, CLOUDFLARE_TUNNEL_TOKEN).
2. Merge desta PR + PR #33 (cloudflared).
3. `docker compose up -d` do traefik + serviços + cloudflared.
4. No painel Cloudflare: tunnel com public hostname curinga `*.rodrigoma.com.br` → `https://traefik:443` (No TLS Verify ON).
5. Remover port-forwards do mesh; aposentar DuckDNS/No-IP.

Parte do plano de migração pós-CGNAT (Claro). Gerado com HAL.