### PR TITLE
Add docker-compose for cloudflare-ddns

### DIFF
--- a/services/cloudflare-ddns/docker-compose.yml
+++ b/services/cloudflare-ddns/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   cloudflare-ddns:
     image: favonia/cloudflare-ddns:latest
-    container_name: cloudflare-ddns
-    hostname: cloudflare-ddns
+    container_name: cf_ddns
+    hostname: cf_ddns
     networks:
       - traefik
     labels:

--- a/services/cloudflare-ddns/docker-compose.yml
+++ b/services/cloudflare-ddns/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       # Sem IPv6 nesta rede.
       - IP6_PROVIDER=none
     restart: unless-stopped
+    user: "${USER_ID}:${GROUP_ID}"
     # Hardening recomendado pela favonia (não precisa de root nem escrita).
     read_only: true
     cap_drop:

--- a/services/cloudflare-ddns/docker-compose.yml
+++ b/services/cloudflare-ddns/docker-compose.yml
@@ -13,8 +13,9 @@ services:
       - TZ=America/Sao_Paulo
       # Reusa o token que o Traefik já usa (Zone:DNS:Edit + Zone:Read em rodrigoma.com.br).
       - CLOUDFLARE_API_TOKEN=${CF_DNS_API_TOKEN}
-      # Mantém ssh.rodrigoma.com.br apontando pro IP público atual da casa.
-      - DOMAINS=ssh.rodrigoma.com.br
+      # Mantém os hostnames dos dois Pi apontando pro IP público atual da casa
+      # (mesma saída pública; a PORTA é que separa Pi4 2072 x Pi5 2064).
+      - DOMAINS=pi4.rodrigoma.com.br,pi5.rodrigoma.com.br
       # PROXIED=false (nuvem CINZA) é OBRIGATÓRIO — SSH não passa pelo proxy da
       # Cloudflare. O favonia cria/atualiza um registro A DNS-only, que tem
       # precedência sobre o curinga *.rodrigoma.com.br (proxied → túnel).

--- a/services/cloudflare-ddns/docker-compose.yml
+++ b/services/cloudflare-ddns/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  cloudflare-ddns:
+    image: favonia/cloudflare-ddns:latest
+    container_name: cloudflare-ddns
+    hostname: cloudflare-ddns
+    networks:
+      - traefik
+    labels:
+      - sqlbak.stop.first=false
+      - sqlbak.start.first=true
+      - com.centurylinklabs.watchtower.enable=true
+    environment:
+      - TZ=America/Sao_Paulo
+      # Reusa o token que o Traefik já usa (Zone:DNS:Edit + Zone:Read em rodrigoma.com.br).
+      - CLOUDFLARE_API_TOKEN=${CF_DNS_API_TOKEN}
+      # Mantém ssh.rodrigoma.com.br apontando pro IP público atual da casa.
+      - DOMAINS=ssh.rodrigoma.com.br
+      # PROXIED=false (nuvem CINZA) é OBRIGATÓRIO — SSH não passa pelo proxy da
+      # Cloudflare. O favonia cria/atualiza um registro A DNS-only, que tem
+      # precedência sobre o curinga *.rodrigoma.com.br (proxied → túnel).
+      - PROXIED=false
+      # Sem IPv6 nesta rede.
+      - IP6_PROVIDER=none
+    restart: unless-stopped
+    # Hardening recomendado pela favonia (não precisa de root nem escrita).
+    read_only: true
+    cap_drop:
+      - all
+    security_opt:
+      - no-new-privileges:true
+    # DDNS: detecta o IP público (via trace da Cloudflare) e mantém o registro A
+    # em dia. Se o IP for estático, nunca muda; se for dinâmico, se auto-corrige.
+    # Multi-arch (arm64 ok no Pi4). Sem ports / sem Traefik (só saída).
+
+networks:
+  traefik:
+    external: true
+    name: traefik


### PR DESCRIPTION
## Serviço: cloudflare-ddns (favonia/cloudflare-ddns)
Atualizador de DNS dinâmico. Mantém **`ssh.rodrigoma.com.br`** apontando pro **IP público atual da casa** (hoje 189.54.144.138, pós-saída do CGNAT em 29/08). Se o IP for estático, nunca muda; se dinâmico, se auto-corrige.

## Por quê
Pós-CGNAT, o SSH externo volta por port-forward (2072). Este registro dá um **hostname fixo** pra não depender de decorar o IP — e sobrevive a troca de IP.

## Detalhes
- **Reusa o `CF_DNS_API_TOKEN`** já existente no /etc/environment (Zone:DNS:Edit + Zone:Read em rodrigoma.com.br). Sem secret novo.
- **`PROXIED=false` (nuvem CINZA)** — obrigatório: SSH não passa pelo proxy da Cloudflare. O favonia cria/atualiza um registro **A DNS-only**, que tem precedência sobre o curinga `*.rodrigoma.com.br` (proxied → túnel). Confirmado via API que hoje NÃO existe registro `ssh` específico (só o curinga), então não há conflito.
- **`IP6_PROVIDER=none`** (sem IPv6 na rede).
- Sem ports, sem Traefik (só saída). Hardening favonia: `read_only`, `cap_drop: all`, `no-new-privileges`.
- Imagem multi-arch (**arm64 ok** no Pi4).

## Deploy
Merge + `git pull` no Pi4 → `docker compose up -d`. Em ~1 min o registro `ssh.rodrigoma.com.br` (A, cinza) é criado. Depois: `ssh -p 2072 pi@ssh.rodrigoma.com.br`.

Gerado pela skill docker-compose-create.